### PR TITLE
feat: add Claude skills for Julia code quality enforcement

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+## Project Overview
+Julia library building quantum circuit for finding sparse basis in image compression.
+
+## Skills
+- [check-code-quality](skills/check-code-quality/SKILL.md) — Review code changes for design principles (DRY, KISS, SOLID, HC/LC), Julia-specific quality (type stability, AD safety, performance), and test quality.
+- [create-pr](skills/create-pr/SKILL.md) — Create a pull request from the current branch.
+
+## Commands
+```bash
+julia --project=. -e 'using Pkg; Pkg.test()'   # Run all tests
+julia --project=. -e 'using Pkg; Pkg.status()'  # Check dependencies
+```
+
+## Git Safety
+- **NEVER force push** (`git push --force`, `git push -f`, `git push --force-with-lease`). This is an absolute rule with no exceptions. Force push can silently destroy other people's work and stashed changes.
+
+## Architecture
+
+### Core Modules
+- `src/ParametricDFT.jl` — Main module, exports, dependency ordering via `include()`
+- `src/loss.jl` — Loss functions (`L1Norm`, `L2Norm`, `MSELoss`) with batched evaluation
+- `src/basis.jl` — Sparse basis abstractions (`QFTBasis`, `EntangledQFTBasis`, `TEBDBasis`)
+- `src/manifolds.jl` — Riemannian manifold abstraction (`UnitaryManifold`, `PhaseManifold`), batched linear algebra
+- `src/optimizers.jl` — Riemannian optimizers (`RiemannianGD`, `RiemannianAdam`) with unified `optimize!` interface
+- `src/training.jl` — Training pipeline (`_train_basis_core`), device management, checkpointing, early stopping
+- `src/qft.jl` — QFT circuit code generation
+- `src/entangled_qft.jl` — Entangled QFT circuit implementation
+- `src/tebd.jl` — TEBD circuit implementation
+- `src/serialization.jl` — Basis save/load (JSON3)
+- `src/compression.jl` — Image compression using learned bases
+- `src/visualization.jl` — Training loss visualization (CairoMakie)
+- `ext/CUDAExt.jl` — GPU extension module for CUDA support
+
+### Abstract Hierarchy Tree
+```
+AbstractSparseBasis
+├── QFTBasis              # Quantum Fourier Transform basis
+├── EntangledQFTBasis     # QFT with entanglement gates
+└── TEBDBasis             # Time-Evolving Block Decimation
+
+AbstractLoss
+├── L1Norm
+├── L2Norm
+└── MSELoss
+
+AbstractRiemannianManifold
+├── UnitaryManifold       # U(n) unitary group
+└── PhaseManifold         # U(1)^d product manifold
+
+AbstractRiemannianOptimizer
+├── RiemannianGD          # Gradient descent with Armijo line search
+└── RiemannianAdam        # Adam with momentum transport
+```
+
+### Key Patterns
+- **Multiple dispatch extensibility**: Add new behavior by defining new subtypes of abstract types and dispatching, not by modifying existing code.
+- **Batched GPU operations**: `batched_matmul`, `batched_adjoint` reduce kernel launches. Batched einsum codes process multiple images in a single call.
+- **Zygote AD compatibility**: No mutation in differentiated paths. Custom `rrule` for `topk_truncate`. Convert `Tuple` to `Vector` for stable AD tangent types.
+- **OMEinsum tensor contractions**: Pre-optimized Einstein summation codes for forward/inverse transforms.
+- **Device abstraction**: `to_device(x, :gpu/:cpu)` with CUDAExt extending functions for GPU arrays.
+- **Circuit parameters**: Stored as `Vector{Matrix{ComplexF64}}`, optimized on Riemannian manifolds.
+
+## Conventions
+
+### File Naming
+- Source files: `src/<feature>.jl` — one feature per file
+- Test files: `test/<feature>_tests.jl`
+- Main module: `src/ParametricDFT.jl` with explicit `include()` ordering
+- Examples: `examples/<demo_name>.jl`
+
+### Naming Conventions
+- **Types**: PascalCase — `QFTBasis`, `UnitaryManifold`, `RiemannianAdam`
+- **Abstract types**: `Abstract` prefix — `AbstractSparseBasis`, `AbstractRiemannianManifold`
+- **Functions**: snake_case — `forward_transform`, `topk_truncate`, `stack_tensors`
+- **Internal functions**: underscore prefix — `_loss_function`, `_compute_gradients`, `_batched_project`
+- **Constants**: UPPER_CASE or CamelCase for singleton-like values
+
+### Code Style
+- Section separators: `# ============================================================================`
+- Broadcast operators for array ops: `.+`, `.*`, `.^`
+- Type annotations in public function signatures
+- Docstrings with triple-quoted strings (`"""..."""`) including purpose, arguments, returns
+- `@assert` for input validation preconditions
+- `@inbounds` with explicit loops for performance-critical sections
+
+## Testing Requirements
+
+### Coverage
+
+New code must have >95% test coverage.
+
+### Naming
+- Test sets: `@testset "FeatureName"` or `@testset "function_name"`
+- Descriptive test names inside testsets
+
+### Key Testing Patterns
+- `Random.seed!(42)` at the start of stochastic tests for reproducibility
+- Numerical accuracy: `@test result ≈ expected atol=1e-10` (never use `==` for floats)
+- Mathematical properties: verify unitarity (`U * U' ≈ I`), manifold membership, loss monotonicity
+- Shape checks paired with value checks — never shape-only
+- Adversarial cases: boundary conditions, degenerate inputs, edge cases
+- Gradient checks: compare AD gradients against finite differences
+
+### File Organization
+- `test/runtests.jl` — main test runner, includes all test files
+- `test/<feature>_tests.jl` — one test file per source module
+- `test/cuda_tests.jl` — GPU-specific tests (separate, requires CUDA)
+- `test/benchmark_test.jl` — performance benchmarks
+
+## Documentation Locations
+- `docs/` — General documentation
+- `docs/plans/` — Design documents and implementation plans
+- `examples/` — Example scripts and demos
+- `note/` — Theoretical notes and prerequisites (Typst)
+
+## Documentation Requirements
+- Public functions must have docstrings with arguments, returns, and examples
+- Design documents go in `docs/plans/YYYY-MM-DD-<topic>.md`
+- New abstract type subtypes must document which interface methods they implement

--- a/.claude/rules/julia-conventions.md
+++ b/.claude/rules/julia-conventions.md
@@ -1,0 +1,63 @@
+---
+description: Julia coding conventions for the ParametricDFT.jl codebase — auto-activated when editing Julia files
+globs: ["*.jl"]
+---
+
+# Julia Conventions for ParametricDFT.jl
+
+Follow these conventions when writing or modifying Julia code in this project.
+
+## Naming
+
+- **Types**: PascalCase — `QFTBasis`, `UnitaryManifold`, `RiemannianAdam`
+- **Abstract types**: `Abstract` prefix — `AbstractSparseBasis`, `AbstractRiemannianManifold`
+- **Functions**: snake_case — `forward_transform`, `topk_truncate`, `stack_tensors`
+- **Internal functions**: underscore prefix — `_loss_function`, `_compute_gradients`
+- **Constants**: UPPER_CASE or CamelCase for singleton-like values
+- **Type parameters**: single uppercase letters — `T`, `M`, `O`
+
+## Type Hierarchy
+
+- New types extending this library MUST subtype the appropriate abstract type
+- Implement all required interface methods for the abstract type (check existing subtypes for the contract)
+- Use multiple dispatch for specialization — NEVER use `if typeof(x) == ConcreteType` branching
+- Keep abstract types minimal: don't add methods unless all subtypes need them
+- Example: a new basis → `struct MyBasis <: AbstractSparseBasis ... end`, then define `forward_transform`, `inverse_transform`, etc.
+
+## Function Design
+
+- Keep functions under 50 lines; extract sub-operations into well-named helpers
+- Public API functions: type annotations in signatures, docstrings with `"""..."""`
+- Preconditions: `@assert condition "message"` at function entry
+- Fatal errors: `error("descriptive message")`
+- Return types should be inferrable from input types (type stability)
+
+## AD Compatibility (Zygote)
+
+These rules apply to ANY code that will be differentiated through (loss functions, forward/inverse transforms, training steps):
+
+- **No mutation**: Never use `push!`, `setindex!`, `fill!`, or `x .= y` in differentiated paths. Construct new arrays instead.
+- **No try/catch**: Zygote cannot differentiate through exception handling. Use conditionals.
+- **Stable tangent types**: Convert `Tuple` to `Vector` when Zygote produces tuple tangents. See `_compute_gradients` in `training.jl` for the pattern.
+- **Custom rrules**: When Zygote doesn't support an operation, define `rrule` in ChainRulesCore. The rrule must be mathematically consistent with the forward function.
+
+## Performance
+
+- **Broadcasting**: Use `.+`, `.*`, `.^` for element-wise array operations, not explicit loops (unless loop is needed for control flow).
+- **Pre-allocation**: In hot loops, pre-allocate output buffers and reuse them across iterations.
+- **`@inbounds`**: Only use when bounds are verified. Always pair with a bounds check or `@assert` outside the loop.
+- **Batching for GPU**: Reduce kernel launches by batching operations. Use `batched_matmul` and batched einsum codes.
+- **Avoid untyped globals**: Global variables in hot paths must be `const`. Pass configuration as function arguments instead.
+
+## Testing
+
+- Every new public function gets a `@testset` block
+- Use `Random.seed!(42)` for reproducibility in stochastic tests
+- Numerical comparisons: `@test result ≈ expected atol=1e-10` — NEVER use `==` for floating-point
+- Verify mathematical properties:
+  - Unitarity: `@test U * U' ≈ I`
+  - Manifold membership after projection/retraction
+  - Loss monotonicity during optimization
+- Include adversarial cases: degenerate inputs, boundary conditions, single-element batches
+- Test files: `test/<feature>_tests.jl`, included from `test/runtests.jl`
+- >95% test coverage required for new code

--- a/.claude/skills/check-code-quality/SKILL.md
+++ b/.claude/skills/check-code-quality/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: check-code-quality
+description: Use after writing or modifying Julia code to review for design principles, Julia-specific quality, and test quality
+---
+
+# Code Quality Review
+
+You are reviewing code changes for quality in the `ParametricDFT.jl` Julia codebase. Review the code fresh with no prior context.
+
+## What Changed
+
+{DIFF_SUMMARY}
+
+## Changed Files
+
+{CHANGED_FILES}
+
+## Plan Step Context (if applicable)
+
+{PLAN_STEP}
+
+## Linked Issue
+
+{ISSUE_CONTEXT}
+
+## Git Range
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+Start by running:
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+Then read the changed files in full.
+
+## Review Criteria
+
+### 1. Design Principles
+
+**DRY (Don't Repeat Yourself)** — Is there duplicated logic that should be extracted into a shared helper? Check for:
+- Copy-pasted matrix operations or linear algebra across files
+- Similar training/optimization loops with minor variations
+- Repeated parameter validation or transformation patterns
+- Duplicated einsum code construction
+
+**KISS (Keep It Simple, Stupid)** — Is the implementation unnecessarily complex? Look for:
+- Over-engineered abstractions (unnecessary type parameters, layers of indirection)
+- Premature generalization (solving problems that don't exist yet)
+- Convoluted control flow that could be simplified
+- God functions (>50 lines doing multiple conceptually distinct things)
+
+**SOLID via Multiple Dispatch** — Does the code follow SOLID principles using Julia's dispatch system?
+- **Single Responsibility**: Each module/file has one concern. Each function does one thing.
+- **Open-Closed**: New behavior added via new subtypes + dispatch, NOT by modifying existing functions with if/else branches.
+- **Liskov Substitution**: Concrete types honor abstract type contracts. A `QFTBasis` works anywhere an `AbstractSparseBasis` is expected.
+- **Interface Segregation**: Abstract types are minimal — don't force subtypes to implement methods they don't need.
+- **Dependency Inversion**: Functions accept abstract types (`AbstractSparseBasis`), not concrete ones (`QFTBasis`), unless there's a specific reason.
+
+**High Cohesion, Low Coupling (HC/LC)** — Does each module have a single, well-defined responsibility?
+- **Low cohesion**: Function doing unrelated things (e.g., computing loss AND managing checkpoints).
+- **High coupling**: Modules reaching into each other's internals or sharing mutable state.
+- **Mixed concerns**: A single file containing both mathematical logic and I/O/serialization.
+- **God functions**: Functions longer than ~50 lines doing multiple conceptually distinct things.
+
+### 2. Julia-Specific Quality
+
+**Type Stability** — Are functions type-stable?
+- Functions returning different types depending on input values (e.g., `if x > 0; return 1; else; return 1.0; end`)
+- Type-unstable container operations (e.g., `Any[]` when element types are known)
+- Untyped global variables used in hot paths (should be `const` or passed as arguments)
+- Abstract type fields in structs without parametric types
+
+**AD Safety (Zygote)** — Is the code safe for automatic differentiation?
+- Mutation (`push!`, `setindex!`, in-place operations) inside code paths that will be differentiated
+- `try/catch` blocks in differentiated paths (Zygote cannot differentiate through these)
+- Custom `rrule` implementations that are inconsistent with the forward function
+- Missing `rrule` for operations Zygote doesn't support (e.g., mutating operations that need AD-safe alternatives)
+
+**Performance** — Are there avoidable performance issues?
+- Unnecessary allocations in hot loops (pre-allocate buffers instead)
+- Missing broadcasting for element-wise array operations (use `.+`, `.*` instead of loops)
+- `@inbounds` used without verified bounds safety
+- Operations that could be batched for GPU efficiency but aren't
+
+### 3. Test Quality
+
+**Meaningful Assertions** — Are tests actually testing correctness?
+- Tests that only check types/shapes without values: e.g., `@test result isa Matrix` without checking contents
+- Tests that mirror the implementation: recomputing the same formula as the code proves nothing
+- Too few assertions for non-trivial code: 1-2 `@test` for complex functions is insufficient
+- `@test true` or `@test length(x) > 0` — vacuous assertions that don't verify behavior
+
+**Mathematical Properties** — Do tests verify mathematical correctness?
+- Unitarity: `@test U * U' ≈ I` for unitary matrices
+- Manifold membership: verify projected points satisfy manifold constraints
+- Loss monotonicity: verify loss decreases over optimization steps
+- Gradient correctness: compare AD gradients against finite differences
+- Numerical tests must use `≈` with explicit `atol`/`rtol`, never `==` for floating-point
+
+**Robustness** — Do tests cover edge cases?
+- Only happy-path tests, no adversarial or boundary cases
+- Trivial instances only (1-2 element problems that pass even with bugs)
+- Missing `Random.seed!()` for reproducibility in stochastic tests
+- No tests for degenerate inputs (zero matrices, identity transforms, single-element batches)
+
+## Output Format
+
+You MUST output in this exact format:
+
+```
+## Code Quality Review
+
+### Design Principles
+- DRY: OK / ISSUE — [description with file:line]
+- KISS: OK / ISSUE — [description with file:line]
+- SOLID: OK / ISSUE — [which principle violated, file:line]
+- HC/LC: OK / ISSUE — [description with file:line]
+
+### Julia-Specific Quality
+- Type Stability: OK / ISSUE — [description with file:line]
+- AD Safety: OK / ISSUE — [description with file:line]
+- Performance: OK / ISSUE — [description with file:line]
+
+### Test Quality
+- Meaningful Assertions: OK / ISSUE
+  - [specific tests flagged with reason and file:line]
+- Mathematical Properties: OK / ISSUE
+  - [missing property checks with file:line]
+- Robustness: OK / ISSUE
+  - [missing edge cases with file:line]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, correctness issues, AD breakage, type instability in hot paths]
+
+#### Important (Should Fix)
+[Architecture problems, missing tests, SOLID violations, performance issues]
+
+#### Minor (Nice to Have)
+[Code style, naming inconsistencies, minor optimization opportunities]
+
+### Summary
+- [list of action items with severity]
+```


### PR DESCRIPTION
## Summary

- Populate `.claude/CLAUDE.md` with project architecture, conventions, testing patterns, and documentation requirements derived from the actual codebase
- Rewrite `check-code-quality` skill with Julia-specific design principle checks (DRY, KISS, SOLID via multiple dispatch, HC/LC), Julia quality checks (type stability, AD safety, performance), and test quality checks
- Add `julia-conventions` rule (auto-triggered on `*.jl` files) with naming, type hierarchy, function design, AD compatibility, performance, and testing conventions

Closes #42

## Test plan

- [ ] Verify CLAUDE.md loads correctly in Claude Code sessions and provides accurate project context
- [ ] Invoke `/check-code-quality` on a code change and verify it produces the structured review output
- [ ] Edit a `.jl` file and verify the `julia-conventions` rule auto-activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)