### PR TITLE
Chore: update CLAUDE.md with git safety rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -5,7 +5,7 @@ Julia library building quantum circuit for finding sparse basis in image compres
 
 ## Skills
 - [check-code-quality](skills/check-code-quality/SKILL.md) — Review code changes for design principles (DRY, KISS, SOLID, HC/LC), Julia-specific quality (type stability, AD safety, performance), and test quality.
-- [create-pr](skills/create-pr/SKILL.md) — Create a pull request from the current branch.
+- [issue-pr](skills/issue-pr/SKILL.md) — Create an issue and a pull request from the current branch.
 
 ## Commands
 ```bash
@@ -15,6 +15,9 @@ julia --project=. -e 'using Pkg; Pkg.status()'  # Check dependencies
 
 ## Git Safety
 - **NEVER force push** (`git push --force`, `git push -f`, `git push --force-with-lease`). This is an absolute rule with no exceptions. Force push can silently destroy other people's work and stashed changes.
+- **NEVER use `GIT_OBJECT_DIRECTORY` env var** to work around commit failures. If `git add` or `git commit` fails with "insufficient permission for adding an object to repository database", fix the root cause by running `git repack -a -d` to consolidate objects into an owned pack file.
+- **Verify after commit** — Run `git fsck --connectivity-only` after each commit to catch object corruption immediately, rather than discovering it sessions later.
+- **NEVER manipulate `.git` internals directly** — Don't copy, move, or create files inside `.git/objects/` manually. Use `git repack` to fix object storage issues.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Add git object corruption prevention rules to CLAUDE.md
- Rules cover: never use `GIT_OBJECT_DIRECTORY`, verify with `git fsck` after commits, never manipulate `.git` internals directly, use `git repack` for object storage issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)