### PR TITLE
Improve GPU training batching and benchmarks

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,20 +1,26 @@
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ImageQualityIndexes = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 MLDatasets = "eb30cadb-4394-5ae3-aed4-317e484a6458"
 ManifoldDiff = "af67fdf4-a580-4b9f-bbec-742ef357defd"
+Manifolds = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 Manopt = "0fc0a36d-df90-57f3-8f93-d78a9fc72bb5"
 NPZ = "15e1cf62-19b3-5cfa-8e77-841668bca605"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 ParametricDFT = "cc2eb9de-5297-4754-b0bd-fdc80c6df40d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [sources]
-ParametricDFT = {path = "/workspace"}
+ParametricDFT = {path = ".."}

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -20,6 +20,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Yao = "5872b779-8223-5990-8dd0-5abbb0748c8c"
+ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [sources]

--- a/examples/optimizer_benchmark.jl
+++ b/examples/optimizer_benchmark.jl
@@ -1,11 +1,14 @@
 # ============================================================================
 # Optimizer Benchmark: PDFT vs Manopt.jl
 # ============================================================================
-# Validates ParametricDFT's customized Riemannian GD optimizer against
-# Manopt.jl's gradient_descent on QuickDraw images.
+# Single public benchmark entry point with two built-in profiles:
+#   1. QuickDraw fairness check against Manopt.jl on a small problem
+#   2. DIV2K speed check for PDFT GD/Adam on a heavier workload
 #
 # Run:
 #   julia --project=examples examples/optimizer_benchmark.jl
+#   julia --project=examples examples/optimizer_benchmark.jl quickdraw_fairness
+#   julia --project=examples examples/optimizer_benchmark.jl div2k_speed
 # ============================================================================
 
 using ParametricDFT
@@ -18,6 +21,7 @@ using Statistics
 using Dates
 using Downloads
 using NPZ
+using Images: load, Gray, channelview
 using ImageQualityIndexes: assess_psnr, assess_ssim
 
 # Manopt stack
@@ -30,43 +34,95 @@ import Zygote
 # Configuration
 # ============================================================================
 
-const M_PARAM = 5
-const N_PARAM = 5
-const IMAGE_SIZE = 32
-
-const N_TRAIN = 20
-const N_TEST = 5
 const SEED = 42
 const GPU_DEVICE = 1
-
-const SMOKE_STEPS = 5
-const FULL_STEPS = 50
-
-const LOSS_K = round(Int, 2^(M_PARAM + N_PARAM) * 0.1)
-const COMPRESSION_RATIOS = [0.8, 0.9, 0.95]
-
-const DATA_DIR = joinpath(@__DIR__, "benchmark", "data", "quickdraw")
-const OUTPUT_DIR = joinpath(@__DIR__, "OptimizerBenchmark", "quickdraw")
-const QUICKDRAW_CATEGORIES = ["cat", "dog", "airplane", "apple", "bicycle"]
 const QUICKDRAW_BASE_URL = "https://storage.googleapis.com/quickdraw_dataset/full/numpy_bitmap"
+const QUICKDRAW_CATEGORIES = ["cat", "dog", "airplane", "apple", "bicycle"]
+const QUICKDRAW_DIR = joinpath(@__DIR__, "benchmark", "data", "quickdraw")
+const DIV2K_DIR = joinpath(@__DIR__, "benchmark", "data", "DIV2K_sample")
+const BASE_OUTPUT_DIR = joinpath(@__DIR__, "OptimizerBenchmark")
+const DEFAULT_PROFILE = :default
 
-const OPTIMIZER_CONFIGS = [
-    ("Manopt-GD",      :manopt, :gradient_descent, :cpu),
-    ("PDFT-GD (cpu)",  :pdft,   :gradient_descent, :cpu),
-    ("PDFT-GD (gpu)",  :pdft,   :gradient_descent, :gpu),
-]
+struct BenchmarkProfile
+    name::String
+    slug::String
+    dataset::Symbol
+    m::Int
+    n::Int
+    n_train::Int
+    n_test::Int
+    smoke_steps::Int
+    full_steps::Int
+    loss_keep_ratio::Float64
+    compression_ratios::Vector{Float64}
+    configs::Vector{NTuple{4, Any}}
+    compare_to_manopt::Bool
+    evaluate_compression::Bool
+end
 
-const PLOT_STYLES = Dict(
-    "Manopt-GD"       => (color=:black,     linestyle=:solid),
-    "PDFT-GD (cpu)"   => (color=:blue,      linestyle=:dash),
-    "PDFT-GD (gpu)"   => (color=:blue,      linestyle=:solid),
-)
+function quickdraw_profile()
+    return BenchmarkProfile(
+        "QuickDraw Fairness",
+        "quickdraw",
+        :quickdraw,
+        5,
+        5,
+        20,
+        5,
+        5,
+        30,
+        0.1,
+        [0.8, 0.9, 0.95],
+        [
+            ("Manopt-GD", :manopt, :gradient_descent, :cpu),
+            ("PDFT-GD (cpu)", :pdft, :gradient_descent, :cpu),
+            ("PDFT-GD (gpu)", :pdft, :gradient_descent, :gpu),
+        ],
+        true,
+        true,
+    )
+end
+
+function div2k_profile()
+    return BenchmarkProfile(
+        "DIV2K Speed",
+        "div2k",
+        :div2k,
+        9,
+        9,
+        4,
+        2,
+        2,
+        10,
+        0.1,
+        [0.9, 0.95],
+        [
+            ("PDFT-GD (cpu)", :pdft, :gradient_descent, :cpu),
+            ("PDFT-GD (gpu)", :pdft, :gradient_descent, :gpu),
+            ("PDFT-Adam (cpu)", :pdft, :adam, :cpu),
+            ("PDFT-Adam (gpu)", :pdft, :adam, :gpu),
+        ],
+        false,
+        true,
+    )
+end
+
+function resolve_profiles(arg::String)
+    arg == "default" && return [quickdraw_profile(), div2k_profile()]
+    arg == "quickdraw_fairness" && return [quickdraw_profile()]
+    arg == "div2k_speed" && return [div2k_profile()]
+    error("Unknown benchmark profile '$arg'. Use default, quickdraw_fairness, or div2k_speed")
+end
+
+image_size(profile::BenchmarkProfile) = 2^profile.m
+loss_k(profile::BenchmarkProfile) = round(Int, 2^(profile.m + profile.n) * profile.loss_keep_ratio)
+output_dir(profile::BenchmarkProfile) = joinpath(BASE_OUTPUT_DIR, profile.slug)
 
 # ============================================================================
 # Data Loading
 # ============================================================================
 
-"""Center-pad a 28x28 QuickDraw image to the benchmark power-of-two size."""
+"""Center-pad a small image to the benchmark power-of-two size."""
 function pad_to_power_of_two(img::AbstractMatrix, target_size::Int)
     h, w = size(img)
     padded = zeros(Float64, target_size, target_size)
@@ -77,10 +133,10 @@ function pad_to_power_of_two(img::AbstractMatrix, target_size::Int)
 end
 
 """Load QuickDraw bitmap images, auto-downloading missing category files."""
-function load_quickdraw()
-    mkpath(DATA_DIR)
+function load_quickdraw(profile::BenchmarkProfile)
+    mkpath(QUICKDRAW_DIR)
     for category in QUICKDRAW_CATEGORIES
-        filepath = joinpath(DATA_DIR, "$(category).npy")
+        filepath = joinpath(QUICKDRAW_DIR, "$(category).npy")
         if !isfile(filepath)
             url = "$(QUICKDRAW_BASE_URL)/$(category).npy"
             @info "Downloading QuickDraw category" category url
@@ -90,35 +146,76 @@ function load_quickdraw()
 
     images = Matrix{Float64}[]
     labels = String[]
+    per_category = ceil(Int, (profile.n_train + profile.n_test) / length(QUICKDRAW_CATEGORIES))
 
-    per_category = ceil(Int, (N_TRAIN + N_TEST) / length(QUICKDRAW_CATEGORIES))
     for category in QUICKDRAW_CATEGORIES
-        data = npzread(joinpath(DATA_DIR, "$(category).npy"))
+        data = npzread(joinpath(QUICKDRAW_DIR, "$(category).npy"))
         n_to_load = min(size(data, 1), per_category)
         for i in 1:n_to_load
             img = reshape(Float64.(data[i, :]), 28, 28) ./ 255.0
-            push!(images, pad_to_power_of_two(img, IMAGE_SIZE))
+            push!(images, pad_to_power_of_two(img, image_size(profile)))
             push!(labels, category)
         end
     end
-    @assert length(images) >= N_TRAIN + N_TEST "Need $(N_TRAIN + N_TEST) QuickDraw images, found $(length(images))"
+
+    n_required = profile.n_train + profile.n_test
+    @assert length(images) >= n_required "Need $n_required QuickDraw images, found $(length(images))"
 
     Random.seed!(SEED)
-    selected = randperm(length(images))[1:(N_TRAIN + N_TEST)]
+    selected = randperm(length(images))[1:n_required]
     images = images[selected]
     labels = labels[selected]
 
-    train_images = images[1:N_TRAIN]
-    test_images = images[N_TRAIN+1:end]
-    test_labels = labels[N_TRAIN+1:end]
+    train_images = images[1:profile.n_train]
+    test_images = images[profile.n_train+1:end]
+    test_labels = labels[profile.n_train+1:end]
 
-    println("  Train: $(length(train_images)) images ($(IMAGE_SIZE)×$(IMAGE_SIZE))")
+    println("  Train: $(length(train_images)) images ($(image_size(profile))x$(image_size(profile)))")
     println("  Test:  $(length(test_images)) images")
     return train_images, test_images, test_labels
 end
 
+"""Load DIV2K images, center-crop to the profile image size."""
+function load_div2k(profile::BenchmarkProfile)
+    all_files = sort(filter(f -> endswith(lowercase(f), ".png"), readdir(DIV2K_DIR; join=true)))
+    n_required = profile.n_train + profile.n_test
+    @assert length(all_files) >= n_required "Need $n_required DIV2K images, found $(length(all_files))"
+
+    Random.seed!(SEED)
+    selected = all_files[randperm(length(all_files))[1:n_required]]
+
+    images = Matrix{Float64}[]
+    labels = String[]
+    side = image_size(profile)
+
+    for path in selected
+        img = load(path)
+        gray = Gray.(img)
+        h, w = size(gray)
+        y0 = (h - side) ÷ 2 + 1
+        x0 = (w - side) ÷ 2 + 1
+        cropped = gray[y0:y0+side-1, x0:x0+side-1]
+        push!(images, Float64.(channelview(cropped)))
+        push!(labels, basename(path))
+    end
+
+    train_images = images[1:profile.n_train]
+    test_images = images[profile.n_train+1:end]
+    test_labels = labels[profile.n_train+1:end]
+
+    println("  Train: $(length(train_images)) images ($(side)x$(side))")
+    println("  Test:  $(length(test_images)) images")
+    return train_images, test_images, test_labels
+end
+
+function load_dataset(profile::BenchmarkProfile)
+    profile.dataset == :quickdraw && return load_quickdraw(profile)
+    profile.dataset == :div2k && return load_div2k(profile)
+    error("Unsupported dataset $(profile.dataset)")
+end
+
 # ============================================================================
-# Manopt Runner
+# Shared Manopt Helpers
 # ============================================================================
 
 """Build ProductManifold of Stiefel(2,2,ℂ) for QFT circuit tensors."""
@@ -127,40 +224,32 @@ function _manopt_manifold(tensors)
     return ProductManifold(ntuple(_ -> S, length(tensors))...)
 end
 
-"""Convert Vector{Matrix} → ArrayPartition for Manopt."""
 _tensors2point(tensors) = ArrayPartition(tensors...)
-
-"""Convert ArrayPartition → Vector{Matrix} from Manopt."""
 _point2tensors(p) = collect(p.x)
 
-"""
-Run Manopt gradient_descent on QFT circuit parameters.
-Returns (loss_trace, final_tensors, elapsed).
-"""
-function run_manopt_gd(train_images, steps)
-    # Build QFT circuit
-    basis = QFTBasis(M_PARAM, N_PARAM)
+# ============================================================================
+# Benchmark Runners
+# ============================================================================
+
+"""Run Manopt gradient_descent on QFT circuit parameters."""
+function run_manopt_gd(profile::BenchmarkProfile, train_images, steps)
+    basis = QFTBasis(profile.m, profile.n)
     tensors = basis.tensors
     optcode = basis.optcode
     inverse_code = basis.inverse_code
-    loss = ParametricDFT.MSELoss(LOSS_K)
+    loss = ParametricDFT.MSELoss(loss_k(profile))
+    images = [ComplexF64.(img) for img in train_images]
 
-    # Convert to Complex{Float64}
-    images = [Complex{Float64}.(img) for img in train_images]
-
-    # Manopt setup
     M = _manopt_manifold(tensors)
     p0 = _tensors2point(tensors)
 
-    # Cost function (averaged over all images)
     f = (M_arg, p) -> begin
         ts = _point2tensors(p)
-        total = sum(ParametricDFT.loss_function(ts, M_PARAM, N_PARAM, optcode, img, loss;
+        total = sum(ParametricDFT.loss_function(ts, profile.m, profile.n, optcode, img, loss;
                     inverse_code=inverse_code) for img in images)
         return Float64(total / length(images))
     end
 
-    # Riemannian gradient
     grad_f = (M_arg, p) -> ManifoldDiff.gradient(
         M_arg, x -> f(M_arg, x), p,
         ManifoldDiff.RiemannianProjectionBackend(AutoZygote())
@@ -171,32 +260,22 @@ function run_manopt_gd(train_images, steps)
             M, f, grad_f, p0;
             stopping_criterion=Manopt.StopAfterIteration(steps),
             record=[:Cost],
-            return_state=true
+            return_state=true,
         )
     end
 
     loss_trace = Float64.(get_record(result))
     final_point = get_solver_result(result)
     final_tensors = _point2tensors(final_point)
-
-    return loss_trace, final_tensors, elapsed
+    return loss_trace, [Matrix{ComplexF64}(t) for t in final_tensors], elapsed
 end
 
-# ============================================================================
-# PDFT Runner
-# ============================================================================
-
-"""
-Run ParametricDFT's customized Riemannian GD on the same full-batch QFT objective
-as Manopt. This avoids `train_basis` epoch/batch accounting so the requested
-`steps` means the same number of optimizer iterations for both frameworks.
-Returns (loss_trace, final_tensors, elapsed).
-"""
-function run_pdft_gd(train_images, steps, device::Symbol)
-    basis = QFTBasis(M_PARAM, N_PARAM)
+"""Run ParametricDFT optimize! directly for fair full-batch step comparison."""
+function run_pdft(profile::BenchmarkProfile, train_images, steps, optimizer::Symbol, device::Symbol)
+    basis = QFTBasis(profile.m, profile.n)
     optcode = basis.optcode
     inverse_code = basis.inverse_code
-    loss = ParametricDFT.MSELoss(LOSS_K)
+    loss = ParametricDFT.MSELoss(loss_k(profile))
 
     tensors = [ParametricDFT.to_device(Matrix{ComplexF64}(t), device) for t in basis.tensors]
     images = [ParametricDFT.to_device(ComplexF64.(img), device) for img in train_images]
@@ -205,10 +284,10 @@ function run_pdft_gd(train_images, steps, device::Symbol)
     batched_optcode = ParametricDFT.optimize_batched_code(flat_batched, blabel, length(images))
     flat_batched_inv, blabel_inv = ParametricDFT.make_batched_code(inverse_code, length(tensors))
     batched_inverse_code = ParametricDFT.optimize_batched_code(flat_batched_inv, blabel_inv, length(images))
-    stacked_images = ParametricDFT.stack_image_batch(images, M_PARAM, N_PARAM)
+    stacked_images = ParametricDFT.stack_image_batch(images, profile.m, profile.n)
 
     loss_fn = ts -> ParametricDFT.loss_function(
-        ts, M_PARAM, N_PARAM, optcode, stacked_images, loss;
+        ts, profile.m, profile.n, optcode, stacked_images, loss;
         inverse_code=inverse_code,
         batched_optcode=batched_optcode,
         batched_inverse_code=batched_inverse_code,
@@ -218,23 +297,16 @@ function run_pdft_gd(train_images, steps, device::Symbol)
         return back(one(real(eltype(ts[1]))))[1]
     end
 
+    opt = optimizer == :adam ? ParametricDFT.RiemannianAdam(lr=0.001) : ParametricDFT.RiemannianGD(lr=0.01)
+
     loss_trace = Float64[]
     elapsed = @elapsed begin
-        tensors = ParametricDFT.optimize!(
-            ParametricDFT.RiemannianGD(lr=0.01),
-            tensors,
-            loss_fn,
-            grad_fn;
-            max_iter=steps,
-            tol=1e-8,
-            loss_trace=loss_trace,
-        )
+        tensors = ParametricDFT.optimize!(opt, tensors, loss_fn, grad_fn;
+                                          max_iter=steps, tol=1e-8, loss_trace=loss_trace)
         device == :gpu && CUDA.synchronize()
     end
 
-    final_tensors = [ComplexF64.(Array(t)) for t in tensors]
-
-    return loss_trace, final_tensors, elapsed
+    return loss_trace, [ComplexF64.(Array(t)) for t in tensors], elapsed
 end
 
 # ============================================================================
@@ -244,11 +316,6 @@ end
 """Serialize complex tensor to JSON-safe format: Vector of [real, imag] pairs."""
 function _tensors_to_json(tensors)
     return [[[real(v), imag(v)] for v in vec(t)] for t in tensors]
-end
-
-"""Deserialize tensors from JSON format back to Vector{Matrix{ComplexF64}}."""
-function _tensors_from_json(json_tensors, rows::Int=2, cols::Int=2)
-    return [reshape([Complex(v[1], v[2]) for v in t], rows, cols) for t in json_tensors]
 end
 
 """Save a single config result to JSON, appending to existing file."""
@@ -266,14 +333,8 @@ function save_result!(path::String, metadata::Dict, config_result::Dict)
     end
 end
 
-"""Load results from JSON."""
-function load_results(path::String)
-    isfile(path) || return nothing
-    return JSON3.read(read(path, String), Dict{String, Any})
-end
-
 # ============================================================================
-# Benchmark Result
+# Benchmark Result Types
 # ============================================================================
 
 struct BenchmarkResult
@@ -290,21 +351,27 @@ struct BenchmarkResult
     error_msg::String
 end
 
+struct CompressionResult
+    label::String
+    ratio::Float64
+    psnr::Float64
+    ssim::Float64
+    kept_pct::Float64
+end
+
 # ============================================================================
-# Benchmark Runner
+# Benchmark Execution
 # ============================================================================
 
-"""Run a single optimizer config. Returns BenchmarkResult."""
-function run_config(label, framework, optimizer, device, train_images, steps)
+function run_config(profile::BenchmarkProfile, label, framework, optimizer, device, train_images, steps)
     @printf("  %-20s ... ", label)
     flush(stdout)
 
     try
-        if framework == :manopt
-            loss_trace, tensors, elapsed = run_manopt_gd(train_images, steps)
+        loss_trace, tensors, elapsed = if framework == :manopt
+            run_manopt_gd(profile, train_images, steps)
         else
-            optimizer == :gradient_descent || error("optimizer_benchmark currently compares Riemannian GD only")
-            loss_trace, tensors, elapsed = run_pdft_gd(train_images, steps, device)
+            run_pdft(profile, train_images, steps, optimizer, device)
         end
 
         final_loss = isempty(loss_trace) ? NaN : last(loss_trace)
@@ -322,19 +389,16 @@ function run_config(label, framework, optimizer, device, train_images, steps)
     end
 end
 
-"""Run all 5 configs at given step count. Save JSON after each."""
-function run_benchmark_phase(phase_name, steps, train_images, json_path, metadata)
+function run_phase(profile::BenchmarkProfile, phase_name::String, steps::Int, train_images, json_path::String, metadata::Dict)
     println("\n" * "=" ^ 70)
-    println("  $phase_name ($steps steps, $(length(train_images)) images)")
+    println("  $(profile.name): $phase_name ($steps steps, $(length(train_images)) images)")
     println("=" ^ 70)
 
     results = BenchmarkResult[]
-
-    for (label, framework, optimizer, device) in OPTIMIZER_CONFIGS
-        result = run_config(label, framework, optimizer, device, train_images, steps)
+    for (label, framework, optimizer, device) in profile.configs
+        result = run_config(profile, label, framework, optimizer, device, train_images, steps)
         push!(results, result)
 
-        # Save to JSON after each config
         if result.success
             config_data = Dict{String, Any}(
                 "label"           => result.label,
@@ -359,27 +423,19 @@ end
 # Compression Evaluation
 # ============================================================================
 
-struct CompressionResult
-    label::String
-    ratio::Float64
-    psnr::Float64
-    ssim::Float64
-    kept_pct::Float64
-end
+function evaluate_all_compression(profile::BenchmarkProfile, results, test_images)
+    profile.evaluate_compression || return CompressionResult[]
 
-"""Evaluate compression quality for all successful configs."""
-function evaluate_all_compression(results, test_images, test_filenames)
     println("\n" * "=" ^ 70)
-    println("  Compression Evaluation")
+    println("  $(profile.name): Compression Evaluation")
     println("=" ^ 70)
 
     all_comp = CompressionResult[]
 
     for r in filter(r -> r.success, results)
-        # Reconstruct QFTBasis from trained tensors
-        basis = QFTBasis(M_PARAM, N_PARAM, r.tensors)
+        basis = QFTBasis(profile.m, profile.n, r.tensors)
 
-        for ratio in COMPRESSION_RATIOS
+        for ratio in profile.compression_ratios
             psnr_vals = Float64[]
             ssim_vals = Float64[]
 
@@ -387,7 +443,6 @@ function evaluate_all_compression(results, test_images, test_filenames)
                 compressed = compress(basis, img; ratio=ratio)
                 recovered = recover(basis, compressed; verify_hash=false)
                 recovered_clamped = clamp.(recovered, 0.0, 1.0)
-
                 push!(psnr_vals, assess_psnr(img, recovered_clamped))
                 push!(ssim_vals, assess_ssim(img, recovered_clamped))
             end
@@ -399,8 +454,7 @@ function evaluate_all_compression(results, test_images, test_filenames)
         end
     end
 
-    # Save compression results
-    comp_path = joinpath(OUTPUT_DIR, "compression_results.json")
+    comp_path = joinpath(output_dir(profile), "compression_results.json")
     comp_data = [Dict("label" => c.label, "ratio" => c.ratio,
                        "psnr" => c.psnr, "ssim" => c.ssim, "kept_pct" => c.kept_pct)
                  for c in all_comp]
@@ -416,34 +470,49 @@ end
 # Visualization
 # ============================================================================
 
-"""Plot 1: Per-step loss curves for all optimizers on one axis (normalized per pixel)."""
-function plot_loss_curves(results)
+function plot_styles(profile::BenchmarkProfile)
+    if profile.slug == "div2k"
+        return Dict(
+            "PDFT-GD (cpu)" => (color=:blue, linestyle=:dash),
+            "PDFT-GD (gpu)" => (color=:blue, linestyle=:solid),
+            "PDFT-Adam (cpu)" => (color=:red, linestyle=:dash),
+            "PDFT-Adam (gpu)" => (color=:red, linestyle=:solid),
+        )
+    end
+    return Dict(
+        "Manopt-GD" => (color=:black, linestyle=:solid),
+        "PDFT-GD (cpu)" => (color=:blue, linestyle=:dash),
+        "PDFT-GD (gpu)" => (color=:blue, linestyle=:solid),
+    )
+end
+
+function plot_loss_curves(profile::BenchmarkProfile, results)
     with_trace = filter(r -> r.success && !isempty(r.loss_trace), results)
     isempty(with_trace) && return nothing
 
-    n_pixels = 2^(M_PARAM + N_PARAM)
+    n_pixels = 2^(profile.m + profile.n)
+    styles = plot_styles(profile)
 
     fig = Figure(size=(900, 600))
     ax = Axis(fig[1, 1];
-              title="QuickDraw Training Loss Convergence ($(IMAGE_SIZE)x$(IMAGE_SIZE), QFT)",
+              title="$(profile.name) Loss Convergence ($(image_size(profile))x$(image_size(profile)), QFT)",
               xlabel="Optimization Step",
               ylabel="MSE per pixel",
               yscale=log10)
 
     for r in with_trace
-        style = get(PLOT_STYLES, r.label, (color=:gray, linestyle=:solid))
+        style = get(styles, r.label, (color=:gray, linestyle=:solid))
         steps = 1:length(r.loss_trace)
         normalized = r.loss_trace ./ n_pixels
-        lines!(ax, steps, normalized;
-               label=r.label, color=style.color, linestyle=style.linestyle, linewidth=2)
+        lines!(ax, steps, normalized; label=r.label, color=style.color,
+               linestyle=style.linestyle, linewidth=2)
     end
 
     axislegend(ax; position=:rt)
     return fig
 end
 
-"""Plot 2: Training time bar chart."""
-function plot_timing(results)
+function plot_timing(profile::BenchmarkProfile, results)
     successful = filter(r -> r.success, results)
     isempty(successful) && return nothing
 
@@ -454,41 +523,51 @@ function plot_timing(results)
 
     fig = Figure(size=(800, 500))
     ax = Axis(fig[1, 1];
-              title="QuickDraw Training Time ($(FULL_STEPS) full-batch GD steps)",
+              title="$(profile.name) Training Time ($(successful[1].steps) steps)",
               ylabel="Time (seconds)",
               xticklabelrotation=π/6)
 
     barplot!(ax, 1:length(times), times; color=colors)
     ax.xticks = (1:length(labels), labels)
-
     return fig
 end
 
-"""Plot 3: Speedup against Manopt and CPU/GPU speedup for customized GD."""
-function plot_optimizer_speedup(results)
+function plot_speedup(profile::BenchmarkProfile, results)
     successful = filter(r -> r.success, results)
+    isempty(successful) && return nothing
 
     speedups = Tuple{String, Float64}[]
 
-    manopt = findfirst(r -> r.label == "Manopt-GD", successful)
-    gd_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)", successful)
-    gd_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)", successful)
-    if manopt !== nothing && gd_cpu !== nothing
-        push!(speedups, ("PDFT CPU / Manopt", successful[manopt].elapsed / successful[gd_cpu].elapsed))
-    end
-    if manopt !== nothing && gd_gpu !== nothing
-        push!(speedups, ("PDFT GPU / Manopt", successful[manopt].elapsed / successful[gd_gpu].elapsed))
-    end
-    if gd_cpu !== nothing && gd_gpu !== nothing
-        push!(speedups, ("GPU / CPU", successful[gd_cpu].elapsed / successful[gd_gpu].elapsed))
+    if profile.compare_to_manopt
+        manopt = findfirst(r -> r.label == "Manopt-GD", successful)
+        gd_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)", successful)
+        gd_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)", successful)
+        if manopt !== nothing && gd_cpu !== nothing
+            push!(speedups, ("PDFT CPU / Manopt", successful[manopt].elapsed / successful[gd_cpu].elapsed))
+        end
+        if manopt !== nothing && gd_gpu !== nothing
+            push!(speedups, ("PDFT GPU / Manopt", successful[manopt].elapsed / successful[gd_gpu].elapsed))
+        end
+        if gd_cpu !== nothing && gd_gpu !== nothing
+            push!(speedups, ("GPU / CPU", successful[gd_cpu].elapsed / successful[gd_gpu].elapsed))
+        end
+    else
+        gd_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)", successful)
+        gd_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)", successful)
+        adam_cpu = findfirst(r -> r.label == "PDFT-Adam (cpu)", successful)
+        adam_gpu = findfirst(r -> r.label == "PDFT-Adam (gpu)", successful)
+        if gd_cpu !== nothing && gd_gpu !== nothing
+            push!(speedups, ("GD GPU / CPU", successful[gd_cpu].elapsed / successful[gd_gpu].elapsed))
+        end
+        if adam_cpu !== nothing && adam_gpu !== nothing
+            push!(speedups, ("Adam GPU / CPU", successful[adam_cpu].elapsed / successful[adam_gpu].elapsed))
+        end
     end
 
     isempty(speedups) && return nothing
 
     fig = Figure(size=(800, 500))
-    ax = Axis(fig[1, 1];
-              title="Customized GD Speedup",
-              ylabel="Speedup factor")
+    ax = Axis(fig[1, 1]; title="$(profile.name) Speedup", ylabel="Speedup factor")
 
     labels = [s[1] for s in speedups]
     values = [s[2] for s in speedups]
@@ -497,30 +576,28 @@ function plot_optimizer_speedup(results)
     barplot!(ax, 1:length(values), values; color=colors)
     ax.xticks = (1:length(labels), labels)
     hlines!(ax, [1.0]; color=:black, linestyle=:dash, linewidth=1)
-
     return fig
 end
 
-"""Plot 4-5: Compression quality (PSNR and SSIM vs kept %)."""
-function plot_compression_quality(comp_results)
+function plot_compression_quality(profile::BenchmarkProfile, comp_results)
     isempty(comp_results) && return nothing, nothing
 
+    styles = plot_styles(profile)
     fig_psnr = Figure(size=(800, 500))
     ax_psnr = Axis(fig_psnr[1, 1];
-                    title="QuickDraw Compression Quality — PSNR ($(IMAGE_SIZE)x$(IMAGE_SIZE), QFT)",
-                    xlabel="Coefficients Kept (%)",
-                    ylabel="PSNR (dB)")
+                   title="$(profile.name) Compression Quality — PSNR",
+                   xlabel="Coefficients Kept (%)",
+                   ylabel="PSNR (dB)")
 
     fig_ssim = Figure(size=(800, 500))
     ax_ssim = Axis(fig_ssim[1, 1];
-                    title="QuickDraw Compression Quality — SSIM ($(IMAGE_SIZE)x$(IMAGE_SIZE), QFT)",
-                    xlabel="Coefficients Kept (%)",
-                    ylabel="SSIM")
+                   title="$(profile.name) Compression Quality — SSIM",
+                   xlabel="Coefficients Kept (%)",
+                   ylabel="SSIM")
 
     optimizer_labels = unique(c.label for c in comp_results)
-
     for opt_label in optimizer_labels
-        style = get(PLOT_STYLES, opt_label, (color=:gray, linestyle=:solid))
+        style = get(styles, opt_label, (color=:gray, linestyle=:solid))
         subset = filter(c -> c.label == opt_label, comp_results)
         sort!(subset; by=c -> c.kept_pct)
 
@@ -539,58 +616,48 @@ function plot_compression_quality(comp_results)
 
     axislegend(ax_psnr; position=:rb)
     axislegend(ax_ssim; position=:rb)
-
     return fig_psnr, fig_ssim
 end
 
-"""Plot 6: Reconstruction grid — original + each optimizer at middle compression ratio."""
-function plot_reconstruction_grid(results, test_images, test_filenames)
+function plot_reconstruction_grid(profile::BenchmarkProfile, results, test_images, test_labels)
     successful = filter(r -> r.success && !isempty(r.tensors), results)
     isempty(successful) && return nothing
 
     n_show = min(length(test_images), 4)
-    ratio = COMPRESSION_RATIOS[2]  # middle ratio (0.9 = keep 10%)
+    ratio = profile.compression_ratios[min(2, length(profile.compression_ratios))]
     kept_pct = round(Int, (1.0 - ratio) * 100)
 
-    n_rows = 1 + length(successful)  # original + each optimizer
+    n_rows = 1 + length(successful)
     fig = Figure(size=(250 * n_show, 220 * n_rows))
 
-    # Row 1: Originals
     for (col, idx) in enumerate(1:n_show)
-        ax = Axis(fig[1, col]; title=test_filenames[idx][1:min(end,12)],
-                  aspect=DataAspect())
+        ax = Axis(fig[1, col]; title=test_labels[idx][1:min(end, 12)], aspect=DataAspect())
         hidedecorations!(ax)
         heatmap!(ax, rotr90(test_images[idx]); colormap=:grays)
     end
     Label(fig[1, 0], "Original"; rotation=π/2, fontsize=12)
 
-    # Rows 2+: Reconstructions
     for (row_idx, r) in enumerate(successful)
-        basis = QFTBasis(M_PARAM, N_PARAM, r.tensors)
-
+        basis = QFTBasis(profile.m, profile.n, r.tensors)
         for (col, idx) in enumerate(1:n_show)
             img = test_images[idx]
             compressed = compress(basis, img; ratio=ratio)
             recovered = clamp.(recover(basis, compressed; verify_hash=false), 0.0, 1.0)
             psnr_val = assess_psnr(img, recovered)
 
-            ax = Axis(fig[row_idx + 1, col];
-                      title=@sprintf("%.1f dB", psnr_val),
+            ax = Axis(fig[row_idx + 1, col]; title=@sprintf("%.1f dB", psnr_val),
                       titlesize=10, aspect=DataAspect())
             hidedecorations!(ax)
             heatmap!(ax, rotr90(recovered); colormap=:grays)
         end
-
         Label(fig[row_idx + 1, 0], r.label; rotation=π/2, fontsize=10)
     end
 
     Label(fig[0, 1:n_show], "Reconstruction Grid (keep $(kept_pct)%)"; fontsize=14)
-
     return fig
 end
 
-"""Plot 7: Final loss comparison bar chart."""
-function plot_final_loss(results)
+function plot_final_loss(profile::BenchmarkProfile, results)
     successful = filter(r -> r.success, results)
     isempty(successful) && return nothing
 
@@ -600,33 +667,27 @@ function plot_final_loss(results)
               for r in successful]
 
     fig = Figure(size=(800, 500))
-    ax = Axis(fig[1, 1];
-              title="Final Training Loss ($(FULL_STEPS) steps)",
-              ylabel="Loss",
-              xticklabelrotation=π/6)
-
+    ax = Axis(fig[1, 1]; title="$(profile.name) Final Training Loss ($(successful[1].steps) steps)",
+              ylabel="Loss", xticklabelrotation=π/6)
     barplot!(ax, 1:length(losses), losses; color=colors)
     ax.xticks = (1:length(labels), labels)
-
     return fig
 end
 
-"""Generate and save all 7 plots."""
-function generate_all_plots(results, comp_results, test_images, test_filenames)
-    plots_dir = joinpath(OUTPUT_DIR, "plots")
+function generate_all_plots(profile::BenchmarkProfile, results, comp_results, test_images, test_labels)
+    plots_dir = joinpath(output_dir(profile), "plots")
     mkpath(plots_dir)
 
-    println("\nGenerating plots...")
-
+    println("\nGenerating plots for $(profile.name)...")
     plots = [
-        ("loss_curves.png",      plot_loss_curves(results)),
-        ("timing.png",           plot_timing(results)),
-        ("optimizer_speedup.png", plot_optimizer_speedup(results)),
-        ("final_loss.png",       plot_final_loss(results)),
-        ("reconstruction.png",   plot_reconstruction_grid(results, test_images, test_filenames)),
+        ("loss_curves.png", plot_loss_curves(profile, results)),
+        ("timing.png", plot_timing(profile, results)),
+        ("speedup.png", plot_speedup(profile, results)),
+        ("final_loss.png", plot_final_loss(profile, results)),
+        ("reconstruction.png", plot_reconstruction_grid(profile, results, test_images, test_labels)),
     ]
 
-    fig_psnr, fig_ssim = plot_compression_quality(comp_results)
+    fig_psnr, fig_ssim = plot_compression_quality(profile, comp_results)
     push!(plots, ("psnr.png", fig_psnr))
     push!(plots, ("ssim.png", fig_ssim))
 
@@ -636,55 +697,98 @@ function generate_all_plots(results, comp_results, test_images, test_filenames)
             println("  $fname")
         end
     end
+end
 
-    println("\nAll plots saved to: $plots_dir")
+# ============================================================================
+# Reporting
+# ============================================================================
+
+function print_summary(profile::BenchmarkProfile, results)
+    successful = filter(r -> r.success, results)
+    isempty(successful) && return
+
+    println("\n" * "=" ^ 70)
+    println("  $(profile.name) Summary")
+    println("=" ^ 70)
+    for r in successful
+        @printf("  %-20s %7.2fs  loss=%.2f\n", r.label, r.elapsed, r.final_loss)
+    end
+
+    if profile.compare_to_manopt
+        manopt = findfirst(r -> r.label == "Manopt-GD", successful)
+        pdft_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)", successful)
+        pdft_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)", successful)
+        if manopt !== nothing && pdft_cpu !== nothing
+            @printf("\n  PDFT-GD CPU speedup over Manopt-GD: %.2fx\n",
+                    successful[manopt].elapsed / successful[pdft_cpu].elapsed)
+        end
+        if manopt !== nothing && pdft_gpu !== nothing
+            @printf("  PDFT-GD GPU speedup over Manopt-GD: %.2fx\n",
+                    successful[manopt].elapsed / successful[pdft_gpu].elapsed)
+        end
+    else
+        gd_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)", successful)
+        gd_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)", successful)
+        adam_cpu = findfirst(r -> r.label == "PDFT-Adam (cpu)", successful)
+        adam_gpu = findfirst(r -> r.label == "PDFT-Adam (gpu)", successful)
+        if gd_cpu !== nothing && gd_gpu !== nothing
+            @printf("\n  GD GPU/CPU speedup: %.2fx\n",
+                    successful[gd_cpu].elapsed / successful[gd_gpu].elapsed)
+        end
+        if adam_cpu !== nothing && adam_gpu !== nothing
+            @printf("  Adam GPU/CPU speedup: %.2fx\n",
+                    successful[adam_cpu].elapsed / successful[adam_gpu].elapsed)
+        end
+    end
 end
 
 # ============================================================================
 # Main
 # ============================================================================
 
-function main()
+function run_profile(profile::BenchmarkProfile)
     println("=" ^ 70)
-    println("  Optimizer Benchmark: PDFT vs Manopt.jl")
+    println("  Optimizer Benchmark: $(profile.name)")
     println("=" ^ 70)
-    println("  Image:    $(IMAGE_SIZE)x$(IMAGE_SIZE) (m=$(M_PARAM), n=$(N_PARAM))")
-    println("  Data:     QuickDraw ($N_TRAIN train, $N_TEST test)")
-    println("  Loss:     MSELoss(k=$(LOSS_K))")
-    println("  Smoke:    $(SMOKE_STEPS) full-batch GD steps")
-    println("  Full:     $(FULL_STEPS) full-batch GD steps")
-    println("  Configs:  $(length(OPTIMIZER_CONFIGS))")
-    println("  GPU:      CUDA device $GPU_DEVICE")
+    println("  Dataset:   $(profile.dataset)")
+    println("  Image:     $(image_size(profile))x$(image_size(profile)) (m=$(profile.m), n=$(profile.n))")
+    println("  Train:     $(profile.n_train) images")
+    println("  Test:      $(profile.n_test) images")
+    println("  Loss:      MSELoss(k=$(loss_k(profile)))")
+    println("  Smoke:     $(profile.smoke_steps) full-batch steps")
+    println("  Full:      $(profile.full_steps) full-batch steps")
+    println("  Configs:   $(length(profile.configs))")
+    println("  GPU:       CUDA device $GPU_DEVICE")
     println("=" ^ 70)
 
     CUDA.device!(GPU_DEVICE)
     @assert CUDA.functional() "GPU $GPU_DEVICE required"
-    println("  CUDA:     $(CUDA.name(CUDA.device()))")
+    println("  CUDA:      $(CUDA.name(CUDA.device()))")
 
-    mkpath(OUTPUT_DIR)
+    mkpath(output_dir(profile))
 
-    # Load data
-    println("\nLoading QuickDraw images...")
-    train_images, test_images, test_filenames = load_quickdraw()
+    println("\nLoading dataset...")
+    train_images, test_images, test_labels = load_dataset(profile)
 
     metadata = Dict{String, Any}(
-        "date"       => Dates.format(now(), "yyyy-mm-dd HH:MM"),
-        "image_size" => "$(IMAGE_SIZE)x$(IMAGE_SIZE)",
-        "dataset" => "quickdraw",
-        "m" => M_PARAM, "n" => N_PARAM,
-        "n_train" => N_TRAIN, "n_test" => N_TEST,
+        "date" => Dates.format(now(), "yyyy-mm-dd HH:MM"),
+        "profile" => profile.slug,
+        "dataset" => String(profile.dataset),
+        "image_size" => "$(image_size(profile))x$(image_size(profile))",
+        "m" => profile.m,
+        "n" => profile.n,
+        "n_train" => profile.n_train,
+        "n_test" => profile.n_test,
         "basis_type" => "QFT",
         "seed" => SEED,
-        "loss_k" => LOSS_K,
+        "loss_k" => loss_k(profile),
         "step_semantics" => "full_batch_optimizer_iterations",
     )
 
-    # Phase 1: Smoke test
     timestamp = Dates.format(now(), "yyyymmdd_HHMMSS")
-    smoke_path = joinpath(OUTPUT_DIR, "smoke_results_$(timestamp).json")
-    smoke_results = run_benchmark_phase("Smoke Test", SMOKE_STEPS, train_images, smoke_path, metadata)
+    smoke_path = joinpath(output_dir(profile), "smoke_results_$(timestamp).json")
+    smoke_results = run_phase(profile, "Smoke Test", profile.smoke_steps, train_images, smoke_path, metadata)
 
-    # Check smoke failures
     failed = filter(r -> !r.success, smoke_results)
     if !isempty(failed)
         println("\nSmoke failures:")
@@ -694,66 +798,54 @@ function main()
     end
     failed_labels = Set(r.label for r in failed)
 
-    # Phase 2: Full run (skip smoke failures)
-    full_path = joinpath(OUTPUT_DIR, "full_results_$(timestamp).json")
-
+    full_path = joinpath(output_dir(profile), "full_results_$(timestamp).json")
     println("\n" * "=" ^ 70)
-    println("  Full Benchmark ($(FULL_STEPS) steps)")
+    println("  $(profile.name): Full Benchmark ($(profile.full_steps) steps)")
     println("=" ^ 70)
 
     full_results = BenchmarkResult[]
-    for (label, framework, optimizer, device) in OPTIMIZER_CONFIGS
+    for (label, framework, optimizer, device) in profile.configs
         if label in failed_labels
             @printf("  %-20s SKIP (failed in smoke)\n", label)
             continue
         end
-        result = run_config(label, framework, optimizer, device, train_images, FULL_STEPS)
+        result = run_config(profile, label, framework, optimizer, device, train_images, profile.full_steps)
         push!(full_results, result)
 
         if result.success
             config_data = Dict{String, Any}(
-                "label"           => result.label,
-                "framework"       => string(result.framework),
-                "optimizer"       => string(result.optimizer),
-                "device"          => string(result.device),
-                "steps"           => result.steps,
+                "label" => result.label,
+                "framework" => string(result.framework),
+                "optimizer" => string(result.optimizer),
+                "device" => string(result.device),
+                "steps" => result.steps,
                 "elapsed_seconds" => result.elapsed,
-                "final_loss"      => result.final_loss,
-                "loss_trace"      => result.loss_trace,
-                "basis_tensors"   => _tensors_to_json(result.tensors),
+                "final_loss" => result.final_loss,
+                "loss_trace" => result.loss_trace,
+                "basis_tensors" => _tensors_to_json(result.tensors),
             )
             save_result!(full_path, metadata, config_data)
             println("    -> Saved to $full_path")
         end
     end
 
-    # Phase 3: Compression evaluation
-    compression_results = evaluate_all_compression(full_results, test_images, test_filenames)
+    compression_results = evaluate_all_compression(profile, full_results, test_images)
+    generate_all_plots(profile, full_results, compression_results, test_images, test_labels)
+    print_summary(profile, full_results)
 
-    # Phase 4: Plots
-    generate_all_plots(full_results, compression_results, test_images, test_filenames)
-
-    manopt = findfirst(r -> r.label == "Manopt-GD" && r.success, full_results)
-    pdft_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)" && r.success, full_results)
-    pdft_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)" && r.success, full_results)
-    if manopt !== nothing && pdft_cpu !== nothing
-        @printf("\nPDFT-GD CPU speedup over Manopt-GD: %.2fx\n",
-                full_results[manopt].elapsed / full_results[pdft_cpu].elapsed)
-    end
-    if manopt !== nothing && pdft_gpu !== nothing
-        @printf("PDFT-GD GPU speedup over Manopt-GD: %.2fx\n",
-                full_results[manopt].elapsed / full_results[pdft_gpu].elapsed)
-    end
-
-    println("\n" * "=" ^ 70)
-    println("  Benchmark complete! Results in: $OUTPUT_DIR")
-    println("=" ^ 70)
-
+    println("\nResults saved to: $(output_dir(profile))")
     return full_results, compression_results
 end
 
-# ============================================================================
-# Run
-# ============================================================================
+function main()
+    arg = isempty(ARGS) ? String(DEFAULT_PROFILE) : ARGS[1]
+    profiles = resolve_profiles(arg)
+    results = []
+    for profile in profiles
+        push!(results, run_profile(profile))
+        println()
+    end
+    return results
+end
 
 main()

--- a/examples/optimizer_benchmark.jl
+++ b/examples/optimizer_benchmark.jl
@@ -1,11 +1,11 @@
 # ============================================================================
 # Optimizer Benchmark: PDFT vs Manopt.jl
 # ============================================================================
-# Validates ParametricDFT's Riemannian optimizers (GD, Adam) against
-# Manopt.jl's gradient_descent on real 512×512 images (DIV2K dataset).
+# Validates ParametricDFT's customized Riemannian GD optimizer against
+# Manopt.jl's gradient_descent on QuickDraw images.
 #
 # Run:
-#   CUDA_VISIBLE_DEVICES=1 julia --project=examples examples/optimizer_benchmark.jl
+#   julia --project=examples examples/optimizer_benchmark.jl
 # ============================================================================
 
 using ParametricDFT
@@ -16,8 +16,8 @@ using Printf
 using Random
 using Statistics
 using Dates
-using Images: load, Gray, channelview
-using FileIO
+using Downloads
+using NPZ
 using ImageQualityIndexes: assess_psnr, assess_ssim
 
 # Manopt stack
@@ -30,80 +30,91 @@ import Zygote
 # Configuration
 # ============================================================================
 
-const M_PARAM = 9
-const N_PARAM = 9
-const IMAGE_SIZE = 512
+const M_PARAM = 5
+const N_PARAM = 5
+const IMAGE_SIZE = 32
 
 const N_TRAIN = 20
 const N_TEST = 5
 const SEED = 42
+const GPU_DEVICE = 1
 
-const SMOKE_STEPS = 50
-const FULL_STEPS = 500
+const SMOKE_STEPS = 5
+const FULL_STEPS = 50
 
 const LOSS_K = round(Int, 2^(M_PARAM + N_PARAM) * 0.1)
 const COMPRESSION_RATIOS = [0.8, 0.9, 0.95]
 
-const DATA_DIR = joinpath(@__DIR__, "data", "DIV2K_valid_HR")
-const OUTPUT_DIR = joinpath(@__DIR__, "OptimizerBenchmark")
+const DATA_DIR = joinpath(@__DIR__, "benchmark", "data", "quickdraw")
+const OUTPUT_DIR = joinpath(@__DIR__, "OptimizerBenchmark", "quickdraw")
+const QUICKDRAW_CATEGORIES = ["cat", "dog", "airplane", "apple", "bicycle"]
+const QUICKDRAW_BASE_URL = "https://storage.googleapis.com/quickdraw_dataset/full/numpy_bitmap"
 
 const OPTIMIZER_CONFIGS = [
     ("Manopt-GD",      :manopt, :gradient_descent, :cpu),
     ("PDFT-GD (cpu)",  :pdft,   :gradient_descent, :cpu),
     ("PDFT-GD (gpu)",  :pdft,   :gradient_descent, :gpu),
-    ("PDFT-Adam (cpu)",:pdft,   :adam,              :cpu),
-    ("PDFT-Adam (gpu)",:pdft,   :adam,              :gpu),
 ]
 
 const PLOT_STYLES = Dict(
     "Manopt-GD"       => (color=:black,     linestyle=:solid),
     "PDFT-GD (cpu)"   => (color=:blue,      linestyle=:dash),
     "PDFT-GD (gpu)"   => (color=:blue,      linestyle=:solid),
-    "PDFT-Adam (cpu)" => (color=:red,       linestyle=:dash),
-    "PDFT-Adam (gpu)" => (color=:red,       linestyle=:solid),
 )
 
 # ============================================================================
 # Data Loading
 # ============================================================================
 
-"""Load DIV2K images, center-crop to 512×512 grayscale."""
-function load_div2k()
-    @assert isdir(DATA_DIR) """
-    DIV2K dataset not found at: $DATA_DIR
-    Download with:
-      cd examples/data
-      curl -LO https://data.vision.ee.ethz.ch/cvl/DIV2K/DIV2K_valid_HR.zip
-      python3 -c "import zipfile; zipfile.ZipFile('DIV2K_valid_HR.zip').extractall()"
-    """
+"""Center-pad a 28x28 QuickDraw image to the benchmark power-of-two size."""
+function pad_to_power_of_two(img::AbstractMatrix, target_size::Int)
+    h, w = size(img)
+    padded = zeros(Float64, target_size, target_size)
+    y_offset = (target_size - h) ÷ 2 + 1
+    x_offset = (target_size - w) ÷ 2 + 1
+    padded[y_offset:y_offset+h-1, x_offset:x_offset+w-1] = Float64.(img)
+    return padded
+end
 
-    all_files = sort(filter(f -> endswith(lowercase(f), ".png"), readdir(DATA_DIR; join=true)))
-    @assert length(all_files) >= N_TRAIN + N_TEST "Need $(N_TRAIN + N_TEST) images, found $(length(all_files))"
-
-    Random.seed!(SEED)
-    selected = all_files[randperm(length(all_files))[1:(N_TRAIN + N_TEST)]]
+"""Load QuickDraw bitmap images, auto-downloading missing category files."""
+function load_quickdraw()
+    mkpath(DATA_DIR)
+    for category in QUICKDRAW_CATEGORIES
+        filepath = joinpath(DATA_DIR, "$(category).npy")
+        if !isfile(filepath)
+            url = "$(QUICKDRAW_BASE_URL)/$(category).npy"
+            @info "Downloading QuickDraw category" category url
+            Downloads.download(url, filepath)
+        end
+    end
 
     images = Matrix{Float64}[]
-    filenames = String[]
+    labels = String[]
 
-    for path in selected
-        img = load(path)
-        gray = Gray.(img)
-        h, w = size(gray)
-        y0 = (h - IMAGE_SIZE) ÷ 2 + 1
-        x0 = (w - IMAGE_SIZE) ÷ 2 + 1
-        cropped = gray[y0:y0+IMAGE_SIZE-1, x0:x0+IMAGE_SIZE-1]
-        push!(images, Float64.(channelview(cropped)))
-        push!(filenames, basename(path))
+    per_category = ceil(Int, (N_TRAIN + N_TEST) / length(QUICKDRAW_CATEGORIES))
+    for category in QUICKDRAW_CATEGORIES
+        data = npzread(joinpath(DATA_DIR, "$(category).npy"))
+        n_to_load = min(size(data, 1), per_category)
+        for i in 1:n_to_load
+            img = reshape(Float64.(data[i, :]), 28, 28) ./ 255.0
+            push!(images, pad_to_power_of_two(img, IMAGE_SIZE))
+            push!(labels, category)
+        end
     end
+    @assert length(images) >= N_TRAIN + N_TEST "Need $(N_TRAIN + N_TEST) QuickDraw images, found $(length(images))"
+
+    Random.seed!(SEED)
+    selected = randperm(length(images))[1:(N_TRAIN + N_TEST)]
+    images = images[selected]
+    labels = labels[selected]
 
     train_images = images[1:N_TRAIN]
     test_images = images[N_TRAIN+1:end]
-    test_filenames = filenames[N_TRAIN+1:end]
+    test_labels = labels[N_TRAIN+1:end]
 
     println("  Train: $(length(train_images)) images ($(IMAGE_SIZE)×$(IMAGE_SIZE))")
     println("  Test:  $(length(test_images)) images")
-    return train_images, test_images, test_filenames
+    return train_images, test_images, test_labels
 end
 
 # ============================================================================
@@ -176,28 +187,54 @@ end
 # ============================================================================
 
 """
-Run ParametricDFT train_basis on QFT circuit.
-Returns (loss_trace, final_tensors, elapsed, history).
+Run ParametricDFT's customized Riemannian GD on the same full-batch QFT objective
+as Manopt. This avoids `train_basis` epoch/batch accounting so the requested
+`steps` means the same number of optimizer iterations for both frameworks.
+Returns (loss_trace, final_tensors, elapsed).
 """
-function run_pdft(train_images, steps, optimizer::Symbol, device::Symbol)
-    images = [Complex{Float64}.(img) for img in train_images]
+function run_pdft_gd(train_images, steps, device::Symbol)
+    basis = QFTBasis(M_PARAM, N_PARAM)
+    optcode = basis.optcode
+    inverse_code = basis.inverse_code
+    loss = ParametricDFT.MSELoss(LOSS_K)
 
-    elapsed = @elapsed begin
-        basis, history = train_basis(QFTBasis, images;
-            m=M_PARAM, n=N_PARAM,
-            loss=ParametricDFT.MSELoss(LOSS_K),
-            epochs=1,
-            steps_per_image=steps,
-            validation_split=0.0,
-            optimizer=optimizer,
-            device=device,
-        )
+    tensors = [ParametricDFT.to_device(Matrix{ComplexF64}(t), device) for t in basis.tensors]
+    images = [ParametricDFT.to_device(ComplexF64.(img), device) for img in train_images]
+
+    flat_batched, blabel = ParametricDFT.make_batched_code(optcode, length(tensors))
+    batched_optcode = ParametricDFT.optimize_batched_code(flat_batched, blabel, length(images))
+    flat_batched_inv, blabel_inv = ParametricDFT.make_batched_code(inverse_code, length(tensors))
+    batched_inverse_code = ParametricDFT.optimize_batched_code(flat_batched_inv, blabel_inv, length(images))
+    stacked_images = ParametricDFT.stack_image_batch(images, M_PARAM, N_PARAM)
+
+    loss_fn = ts -> ParametricDFT.loss_function(
+        ts, M_PARAM, N_PARAM, optcode, stacked_images, loss;
+        inverse_code=inverse_code,
+        batched_optcode=batched_optcode,
+        batched_inverse_code=batched_inverse_code,
+    )
+    grad_fn = ts -> begin
+        _, back = Zygote.pullback(loss_fn, ts)
+        return back(one(real(eltype(ts[1]))))[1]
     end
 
-    loss_trace = history.step_train_losses
-    final_tensors = basis.tensors
+    loss_trace = Float64[]
+    elapsed = @elapsed begin
+        tensors = ParametricDFT.optimize!(
+            ParametricDFT.RiemannianGD(lr=0.01),
+            tensors,
+            loss_fn,
+            grad_fn;
+            max_iter=steps,
+            tol=1e-8,
+            loss_trace=loss_trace,
+        )
+        device == :gpu && CUDA.synchronize()
+    end
 
-    return loss_trace, final_tensors, elapsed, history
+    final_tensors = [ComplexF64.(Array(t)) for t in tensors]
+
+    return loss_trace, final_tensors, elapsed
 end
 
 # ============================================================================
@@ -266,7 +303,8 @@ function run_config(label, framework, optimizer, device, train_images, steps)
         if framework == :manopt
             loss_trace, tensors, elapsed = run_manopt_gd(train_images, steps)
         else
-            loss_trace, tensors, elapsed, _ = run_pdft(train_images, steps, optimizer, device)
+            optimizer == :gradient_descent || error("optimizer_benchmark currently compares Riemannian GD only")
+            loss_trace, tensors, elapsed = run_pdft_gd(train_images, steps, device)
         end
 
         final_loss = isempty(loss_trace) ? NaN : last(loss_trace)
@@ -387,7 +425,7 @@ function plot_loss_curves(results)
 
     fig = Figure(size=(900, 600))
     ax = Axis(fig[1, 1];
-              title="Training Loss Convergence ($(IMAGE_SIZE)×$(IMAGE_SIZE), QFT)",
+              title="QuickDraw Training Loss Convergence ($(IMAGE_SIZE)x$(IMAGE_SIZE), QFT)",
               xlabel="Optimization Step",
               ylabel="MSE per pixel",
               yscale=log10)
@@ -416,7 +454,7 @@ function plot_timing(results)
 
     fig = Figure(size=(800, 500))
     ax = Axis(fig[1, 1];
-              title="Training Time ($(FULL_STEPS) steps, $(IMAGE_SIZE)×$(IMAGE_SIZE))",
+              title="QuickDraw Training Time ($(FULL_STEPS) full-batch GD steps)",
               ylabel="Time (seconds)",
               xticklabelrotation=π/6)
 
@@ -426,31 +464,30 @@ function plot_timing(results)
     return fig
 end
 
-"""Plot 3: GPU speedup (CPU time / GPU time) for GD and Adam."""
-function plot_gpu_speedup(results)
+"""Plot 3: Speedup against Manopt and CPU/GPU speedup for customized GD."""
+function plot_optimizer_speedup(results)
     successful = filter(r -> r.success, results)
 
     speedups = Tuple{String, Float64}[]
 
-    # GD speedup
+    manopt = findfirst(r -> r.label == "Manopt-GD", successful)
     gd_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)", successful)
     gd_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)", successful)
-    if gd_cpu !== nothing && gd_gpu !== nothing
-        push!(speedups, ("GD", successful[gd_cpu].elapsed / successful[gd_gpu].elapsed))
+    if manopt !== nothing && gd_cpu !== nothing
+        push!(speedups, ("PDFT CPU / Manopt", successful[manopt].elapsed / successful[gd_cpu].elapsed))
     end
-
-    # Adam speedup
-    adam_cpu = findfirst(r -> r.label == "PDFT-Adam (cpu)", successful)
-    adam_gpu = findfirst(r -> r.label == "PDFT-Adam (gpu)", successful)
-    if adam_cpu !== nothing && adam_gpu !== nothing
-        push!(speedups, ("Adam", successful[adam_cpu].elapsed / successful[adam_gpu].elapsed))
+    if manopt !== nothing && gd_gpu !== nothing
+        push!(speedups, ("PDFT GPU / Manopt", successful[manopt].elapsed / successful[gd_gpu].elapsed))
+    end
+    if gd_cpu !== nothing && gd_gpu !== nothing
+        push!(speedups, ("GPU / CPU", successful[gd_cpu].elapsed / successful[gd_gpu].elapsed))
     end
 
     isempty(speedups) && return nothing
 
-    fig = Figure(size=(500, 500))
+    fig = Figure(size=(800, 500))
     ax = Axis(fig[1, 1];
-              title="GPU Speedup (CPU time / GPU time)",
+              title="Customized GD Speedup",
               ylabel="Speedup factor")
 
     labels = [s[1] for s in speedups]
@@ -470,13 +507,13 @@ function plot_compression_quality(comp_results)
 
     fig_psnr = Figure(size=(800, 500))
     ax_psnr = Axis(fig_psnr[1, 1];
-                    title="Compression Quality — PSNR ($(IMAGE_SIZE)×$(IMAGE_SIZE), QFT)",
+                    title="QuickDraw Compression Quality — PSNR ($(IMAGE_SIZE)x$(IMAGE_SIZE), QFT)",
                     xlabel="Coefficients Kept (%)",
                     ylabel="PSNR (dB)")
 
     fig_ssim = Figure(size=(800, 500))
     ax_ssim = Axis(fig_ssim[1, 1];
-                    title="Compression Quality — SSIM ($(IMAGE_SIZE)×$(IMAGE_SIZE), QFT)",
+                    title="QuickDraw Compression Quality — SSIM ($(IMAGE_SIZE)x$(IMAGE_SIZE), QFT)",
                     xlabel="Coefficients Kept (%)",
                     ylabel="SSIM")
 
@@ -584,7 +621,7 @@ function generate_all_plots(results, comp_results, test_images, test_filenames)
     plots = [
         ("loss_curves.png",      plot_loss_curves(results)),
         ("timing.png",           plot_timing(results)),
-        ("gpu_speedup.png",      plot_gpu_speedup(results)),
+        ("optimizer_speedup.png", plot_optimizer_speedup(results)),
         ("final_loss.png",       plot_final_loss(results)),
         ("reconstruction.png",   plot_reconstruction_grid(results, test_images, test_filenames)),
     ]
@@ -611,32 +648,35 @@ function main()
     println("=" ^ 70)
     println("  Optimizer Benchmark: PDFT vs Manopt.jl")
     println("=" ^ 70)
-    println("  Image:    $(IMAGE_SIZE)×$(IMAGE_SIZE) (m=$(M_PARAM), n=$(N_PARAM))")
-    println("  Data:     DIV2K ($N_TRAIN train, $N_TEST test)")
+    println("  Image:    $(IMAGE_SIZE)x$(IMAGE_SIZE) (m=$(M_PARAM), n=$(N_PARAM))")
+    println("  Data:     QuickDraw ($N_TRAIN train, $N_TEST test)")
     println("  Loss:     MSELoss(k=$(LOSS_K))")
-    println("  Smoke:    $(SMOKE_STEPS) steps")
-    println("  Full:     $(FULL_STEPS) steps")
+    println("  Smoke:    $(SMOKE_STEPS) full-batch GD steps")
+    println("  Full:     $(FULL_STEPS) full-batch GD steps")
     println("  Configs:  $(length(OPTIMIZER_CONFIGS))")
-    println("  CUDA:     $(CUDA.functional() ? CUDA.name(CUDA.device()) : "NOT AVAILABLE")")
+    println("  GPU:      CUDA device $GPU_DEVICE")
     println("=" ^ 70)
 
-    @assert CUDA.functional() "GPU required"
-    CUDA.device!(0)
+    CUDA.device!(GPU_DEVICE)
+    @assert CUDA.functional() "GPU $GPU_DEVICE required"
+    println("  CUDA:     $(CUDA.name(CUDA.device()))")
 
     mkpath(OUTPUT_DIR)
 
     # Load data
-    println("\nLoading DIV2K images...")
-    train_images, test_images, test_filenames = load_div2k()
+    println("\nLoading QuickDraw images...")
+    train_images, test_images, test_filenames = load_quickdraw()
 
     metadata = Dict{String, Any}(
         "date"       => Dates.format(now(), "yyyy-mm-dd HH:MM"),
         "image_size" => "$(IMAGE_SIZE)x$(IMAGE_SIZE)",
+        "dataset" => "quickdraw",
         "m" => M_PARAM, "n" => N_PARAM,
         "n_train" => N_TRAIN, "n_test" => N_TEST,
         "basis_type" => "QFT",
         "seed" => SEED,
         "loss_k" => LOSS_K,
+        "step_semantics" => "full_batch_optimizer_iterations",
     )
 
     # Phase 1: Smoke test
@@ -692,6 +732,18 @@ function main()
 
     # Phase 4: Plots
     generate_all_plots(full_results, compression_results, test_images, test_filenames)
+
+    manopt = findfirst(r -> r.label == "Manopt-GD" && r.success, full_results)
+    pdft_cpu = findfirst(r -> r.label == "PDFT-GD (cpu)" && r.success, full_results)
+    pdft_gpu = findfirst(r -> r.label == "PDFT-GD (gpu)" && r.success, full_results)
+    if manopt !== nothing && pdft_cpu !== nothing
+        @printf("\nPDFT-GD CPU speedup over Manopt-GD: %.2fx\n",
+                full_results[manopt].elapsed / full_results[pdft_cpu].elapsed)
+    end
+    if manopt !== nothing && pdft_gpu !== nothing
+        @printf("PDFT-GD GPU speedup over Manopt-GD: %.2fx\n",
+                full_results[manopt].elapsed / full_results[pdft_gpu].elapsed)
+    end
 
     println("\n" * "=" ^ 70)
     println("  Benchmark complete! Results in: $OUTPUT_DIR")

--- a/src/ParametricDFT.jl
+++ b/src/ParametricDFT.jl
@@ -12,7 +12,7 @@ using CairoMakie
 using LinearAlgebra
 
 # Loss function exports
-export AbstractLoss, L1Norm, L2Norm, MSELoss
+export AbstractLoss, L1Norm, MSELoss
 export topk_truncate, loss_function
 
 # QFT circuit exports

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -287,9 +287,11 @@ function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.Abstrac
     if batched_optcode !== nothing
         if loss isa L1Norm
             return batched_loss_l1(batched_optcode, tensors, stacked_pics)
-        else  # MSELoss
+        elseif loss isa MSELoss
             return batched_loss_mse(batched_optcode, tensors, stacked_pics, m, n, loss.k, inverse_code;
                                     batched_inverse_code=batched_inverse_code)
+        else
+            error("unsupported loss type for batched dispatch: $(typeof(loss))")
         end
     else
         error("A pre-stacked batch requires batched_optcode")

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -244,12 +244,7 @@ function batched_loss_mse(optcode_batched, tensors::Tuple, batch_data, m::Int, n
         # Single einsum call for all B inverse transforms
         stacked_trunc = cat(truncated_slices...; dims=m + n + 1)
         inv_batched = batched_inverse_code(conj_tensors..., stacked_trunc)
-        total_loss = zero(real(eltype(fft_batched)))
-        for i in 1:B
-            reconstructed = reshape(selectdim(inv_batched, m + n + 1, i), 2^m, 2^n)
-            pic = reshape(selectdim(stacked_batch, m + n + 1, i), 2^m, 2^n)
-            total_loss += sum(abs2.(pic .- reconstructed))
-        end
+        total_loss = sum(abs2.(stacked_batch .- inv_batched))
     else
         # Fallback: per-image inverse
         total_loss = zero(real(eltype(fft_batched)))

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -9,19 +9,6 @@ abstract type AbstractLoss end
 """L1 norm loss: minimizes `sum(|T(x)|)` to encourage sparsity."""
 struct L1Norm <: AbstractLoss end
 
-"""
-    L2Norm
-
-L2 norm loss: `sum(|T(x)|^2)`.
-
-!!! warning
-    Unitary transforms preserve the L2 norm (Parseval's theorem), so this loss
-    is constant with respect to the circuit parameters and its gradient is zero.
-    It should NOT be used as a training objective. Use `L1Norm` or `MSELoss` instead.
-    This type is retained for backward compatibility but may be removed in a future release.
-"""
-struct L2Norm <: AbstractLoss end
-
 """MSE loss with top-k truncation: `||x - T⁻¹(truncate(T(x), k))||²`. Field `k` is the number of kept coefficients."""
 struct MSELoss <: AbstractLoss
     k::Int
@@ -118,11 +105,6 @@ function _loss_function(fft_res, pic, loss::L1Norm, tensors, m, n, inverse_code)
     return sum(abs.(fft_res))
 end
 
-# Compute L2 norm: sum of squared magnitudes
-function _loss_function(fft_res, pic, loss::L2Norm, tensors, m, n, inverse_code)
-    return sum(abs2.(fft_res))
-end
-
 # Compute MSE with truncation: ||x - T⁻¹(truncate(T(x), k))||²₂
 function _loss_function(fft_res, pic, loss::MSELoss, tensors, m, n, inverse_code)
     if inverse_code === nothing
@@ -211,16 +193,6 @@ function batched_loss_l1(optcode_batched, tensors::Tuple, batch::Vector{<:Abstra
     return batched_loss_l1(optcode_batched, tensors, stack_image_batch(batch, m, n))
 end
 
-"""Batched L2 loss: (1/B) * sum(|forward(images)|^2)."""
-function batched_loss_l2(optcode_batched, tensors::Tuple, stacked_batch::AbstractArray)
-    result = batched_forward(optcode_batched, tensors, stacked_batch)
-    return sum(abs2.(result)) / size(stacked_batch, ndims(stacked_batch))
-end
-
-function batched_loss_l2(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
-    return batched_loss_l2(optcode_batched, tensors, stack_image_batch(batch, m, n))
-end
-
 """Batched MSE loss: batched forward, per-image topk_truncate, batched inverse."""
 function batched_loss_mse(optcode_batched, tensors::Tuple, batch_data, m::Int, n::Int, k::Int, inverse_code;
                           batched_inverse_code=nothing)
@@ -264,10 +236,8 @@ end
 # when splatting. Same pattern as loss_function.
 batched_forward(oc, ts::AbstractVector, b::AbstractArray) = batched_forward(oc, Tuple(ts), b)
 batched_loss_l1(oc, ts::AbstractVector, b, m, n) = batched_loss_l1(oc, Tuple(ts), b, m, n)
-batched_loss_l2(oc, ts::AbstractVector, b, m, n) = batched_loss_l2(oc, Tuple(ts), b, m, n)
 batched_loss_mse(oc, ts::AbstractVector, b, m, n, k, ic; kw...) = batched_loss_mse(oc, Tuple(ts), b, m, n, k, ic; kw...)
 batched_loss_l1(oc, ts::AbstractVector, b::AbstractArray) = batched_loss_l1(oc, Tuple(ts), b)
-batched_loss_l2(oc, ts::AbstractVector, b::AbstractArray) = batched_loss_l2(oc, Tuple(ts), b)
 
 # ============================================================================
 # Unified Batch Loss Interface
@@ -317,8 +287,6 @@ function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.Abstrac
     if batched_optcode !== nothing
         if loss isa L1Norm
             return batched_loss_l1(batched_optcode, tensors, stacked_pics)
-        elseif loss isa L2Norm
-            return batched_loss_l2(batched_optcode, tensors, stacked_pics)
         else  # MSELoss
             return batched_loss_mse(batched_optcode, tensors, stacked_pics, m, n, loss.k, inverse_code;
                                     batched_inverse_code=batched_inverse_code)

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -185,34 +185,51 @@ function optimize_batched_code(batched_flat, batch_label, batch_size::Int)
     return optimize_code_cached(batched_flat, size_dict, TreeSA())
 end
 
+"""Stack B images into a single `(2, ..., 2, B)` tensor for batched einsum."""
+function stack_image_batch(batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
+    qubit_dims = fill(2, m + n)
+    return cat([reshape(img, qubit_dims...) for img in batch]...; dims=m + n + 1)
+end
+
+"""Apply circuit to a pre-stacked image batch. Returns (2,...,2,B) tensor."""
+function batched_forward(optcode_batched, tensors::Tuple, stacked_batch::AbstractArray)
+    return optcode_batched(tensors..., stacked_batch)
+end
+
 """Apply circuit to B images in a single einsum call. Returns (2,...,2,B) tensor."""
 function batched_forward(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
-    qubit_dims = fill(2, m + n)
-    # Stack B images into a single (2,2,...,2, B) tensor
-    stacked = cat([reshape(img, qubit_dims...) for img in batch]...; dims=m + n + 1)
-    return optcode_batched(tensors..., stacked)
+    return batched_forward(optcode_batched, tensors, stack_image_batch(batch, m, n))
 end
 
 """Batched L1 loss: (1/B) * sum(|forward(images)|)."""
+function batched_loss_l1(optcode_batched, tensors::Tuple, stacked_batch::AbstractArray)
+    result = batched_forward(optcode_batched, tensors, stacked_batch)
+    return sum(abs.(result)) / size(stacked_batch, ndims(stacked_batch))
+end
+
 function batched_loss_l1(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
-    result = batched_forward(optcode_batched, tensors, batch, m, n)
-    return sum(abs.(result)) / length(batch)
+    return batched_loss_l1(optcode_batched, tensors, stack_image_batch(batch, m, n))
 end
 
 """Batched L2 loss: (1/B) * sum(|forward(images)|^2)."""
+function batched_loss_l2(optcode_batched, tensors::Tuple, stacked_batch::AbstractArray)
+    result = batched_forward(optcode_batched, tensors, stacked_batch)
+    return sum(abs2.(result)) / size(stacked_batch, ndims(stacked_batch))
+end
+
 function batched_loss_l2(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
-    result = batched_forward(optcode_batched, tensors, batch, m, n)
-    return sum(abs2.(result)) / length(batch)
+    return batched_loss_l2(optcode_batched, tensors, stack_image_batch(batch, m, n))
 end
 
 """Batched MSE loss: batched forward, per-image topk_truncate, batched inverse."""
-function batched_loss_mse(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int, k::Int, inverse_code;
+function batched_loss_mse(optcode_batched, tensors::Tuple, batch_data, m::Int, n::Int, k::Int, inverse_code;
                           batched_inverse_code=nothing)
-    B = length(batch)
+    stacked_batch = batch_data isa AbstractVector{<:AbstractMatrix} ? stack_image_batch(batch_data, m, n) : batch_data
+    B = size(stacked_batch, ndims(stacked_batch))
     qubit_dims = fill(2, m + n)
 
     # Batched forward pass — single einsum call
-    fft_batched = batched_forward(optcode_batched, tensors, batch, m, n)
+    fft_batched = batched_forward(optcode_batched, tensors, stacked_batch)
 
     # Per-image truncation (mask is content-dependent, cannot be batched)
     # Use map instead of mutation to keep Zygote happy
@@ -230,7 +247,8 @@ function batched_loss_mse(optcode_batched, tensors::Tuple, batch::Vector{<:Abstr
         total_loss = zero(real(eltype(fft_batched)))
         for i in 1:B
             reconstructed = reshape(selectdim(inv_batched, m + n + 1, i), 2^m, 2^n)
-            total_loss += sum(abs2.(batch[i] .- reconstructed))
+            pic = reshape(selectdim(stacked_batch, m + n + 1, i), 2^m, 2^n)
+            total_loss += sum(abs2.(pic .- reconstructed))
         end
     else
         # Fallback: per-image inverse
@@ -240,7 +258,8 @@ function batched_loss_mse(optcode_batched, tensors::Tuple, batch::Vector{<:Abstr
                 inverse_code(conj_tensors..., truncated_slices[i]),
                 2^m, 2^n
             )
-            total_loss += sum(abs2.(batch[i] .- reconstructed))
+            pic = reshape(selectdim(stacked_batch, m + n + 1, i), 2^m, 2^n)
+            total_loss += sum(abs2.(pic .- reconstructed))
         end
     end
     return total_loss / B
@@ -248,9 +267,12 @@ end
 
 # Vector→Tuple wrapper methods to avoid Zygote vector-vs-tuple tangent mismatch
 # when splatting. Same pattern as loss_function.
+batched_forward(oc, ts::AbstractVector, b::AbstractArray) = batched_forward(oc, Tuple(ts), b)
 batched_loss_l1(oc, ts::AbstractVector, b, m, n) = batched_loss_l1(oc, Tuple(ts), b, m, n)
 batched_loss_l2(oc, ts::AbstractVector, b, m, n) = batched_loss_l2(oc, Tuple(ts), b, m, n)
 batched_loss_mse(oc, ts::AbstractVector, b, m, n, k, ic; kw...) = batched_loss_mse(oc, Tuple(ts), b, m, n, k, ic; kw...)
+batched_loss_l1(oc, ts::AbstractVector, b::AbstractArray) = batched_loss_l1(oc, Tuple(ts), b)
+batched_loss_l2(oc, ts::AbstractVector, b::AbstractArray) = batched_loss_l2(oc, Tuple(ts), b)
 
 # ============================================================================
 # Unified Batch Loss Interface
@@ -273,14 +295,9 @@ function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.Abstrac
                        pics::Vector{<:AbstractMatrix}, loss::AbstractLoss;
                        inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
     if batched_optcode !== nothing
-        if loss isa L1Norm
-            return batched_loss_l1(batched_optcode, tensors, pics, m, n)
-        elseif loss isa L2Norm
-            return batched_loss_l2(batched_optcode, tensors, pics, m, n)
-        else  # MSELoss
-            return batched_loss_mse(batched_optcode, tensors, pics, m, n, loss.k, inverse_code;
-                                    batched_inverse_code=batched_inverse_code)
-        end
+        return loss_function(tensors, m, n, optcode, stack_image_batch(pics, m, n), loss;
+                             inverse_code=inverse_code, batched_optcode=batched_optcode,
+                             batched_inverse_code=batched_inverse_code)
     else
         n_imgs = length(pics)
         total = zero(real(eltype(tensors[1])))
@@ -288,5 +305,30 @@ function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.Abstrac
             total += loss_function(tensors, m, n, optcode, img, loss; inverse_code=inverse_code)
         end
         return total / n_imgs
+    end
+end
+
+function loss_function(tensors::AbstractVector, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
+                       stacked_pics::AbstractArray, loss::AbstractLoss;
+                       inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
+    return loss_function(Tuple(tensors), m, n, optcode, stacked_pics, loss;
+                         inverse_code=inverse_code, batched_optcode=batched_optcode,
+                         batched_inverse_code=batched_inverse_code)
+end
+
+function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
+                       stacked_pics::AbstractArray, loss::AbstractLoss;
+                       inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
+    if batched_optcode !== nothing
+        if loss isa L1Norm
+            return batched_loss_l1(batched_optcode, tensors, stacked_pics)
+        elseif loss isa L2Norm
+            return batched_loss_l2(batched_optcode, tensors, stacked_pics)
+        else  # MSELoss
+            return batched_loss_mse(batched_optcode, tensors, stacked_pics, m, n, loss.k, inverse_code;
+                                    batched_inverse_code=batched_inverse_code)
+        end
+    else
+        error("A pre-stacked batch requires batched_optcode")
     end
 end

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -80,6 +80,14 @@ function ChainRulesCore.rrule(::typeof(topk_truncate), x::AbstractMatrix{T}, k::
 end
 
 # ============================================================================
+# Tuple/Vector Normalization
+# ============================================================================
+
+"""Convert AbstractVector tensors to Tuple for stable Zygote AD tangent types."""
+_ensure_tuple(t::Tuple) = t
+_ensure_tuple(t::AbstractVector) = Tuple(t)
+
+# ============================================================================
 # Loss Function Computation
 # ============================================================================
 
@@ -88,16 +96,11 @@ end
 
 Compute loss for a single image `pic` (2^m x 2^n) under the given circuit parameters.
 """
-function loss_function(tensors::AbstractVector, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum, pic::AbstractMatrix, loss::AbstractLoss; inverse_code=nothing)
-    # Avoid splatting an AbstractVector during AD; Zygote may produce tuple tangents for varargs.
-    # We delegate to the Tuple method for a stable tangent type.
-    return loss_function(Tuple(tensors), m, n, optcode, pic, loss; inverse_code=inverse_code)
-end
-
-function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum, pic::AbstractMatrix, loss::AbstractLoss; inverse_code=nothing)
+function loss_function(tensors, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum, pic::AbstractMatrix, loss::AbstractLoss; inverse_code=nothing)
+    ts = _ensure_tuple(tensors)
     @assert (size(pic) == (2^m, 2^n)) "Input matrix size must be 2^m × 2^n"
-    fft_pic = reshape(optcode(tensors..., reshape(pic, fill(2, m+n)...)), 2^m, 2^n)
-    return _loss_function(fft_pic, pic, loss, tensors, m, n, inverse_code)
+    fft_pic = reshape(optcode(ts..., reshape(pic, fill(2, m+n)...)), 2^m, 2^n)
+    return _loss_function(fft_pic, pic, loss, ts, m, n, inverse_code)
 end
 
 # Compute L1 norm: sum of absolute values
@@ -174,34 +177,35 @@ function stack_image_batch(batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
 end
 
 """Apply circuit to a pre-stacked image batch. Returns (2,...,2,B) tensor."""
-function batched_forward(optcode_batched, tensors::Tuple, stacked_batch::AbstractArray)
-    return optcode_batched(tensors..., stacked_batch)
+function batched_forward(optcode_batched, tensors, stacked_batch::AbstractArray)
+    return optcode_batched(_ensure_tuple(tensors)..., stacked_batch)
 end
 
 """Apply circuit to B images in a single einsum call. Returns (2,...,2,B) tensor."""
-function batched_forward(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
+function batched_forward(optcode_batched, tensors, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
     return batched_forward(optcode_batched, tensors, stack_image_batch(batch, m, n))
 end
 
 """Batched L1 loss: (1/B) * sum(|forward(images)|)."""
-function batched_loss_l1(optcode_batched, tensors::Tuple, stacked_batch::AbstractArray)
+function batched_loss_l1(optcode_batched, tensors, stacked_batch::AbstractArray)
     result = batched_forward(optcode_batched, tensors, stacked_batch)
     return sum(abs.(result)) / size(stacked_batch, ndims(stacked_batch))
 end
 
-function batched_loss_l1(optcode_batched, tensors::Tuple, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
+function batched_loss_l1(optcode_batched, tensors, batch::Vector{<:AbstractMatrix}, m::Int, n::Int)
     return batched_loss_l1(optcode_batched, tensors, stack_image_batch(batch, m, n))
 end
 
 """Batched MSE loss: batched forward, per-image topk_truncate, batched inverse."""
-function batched_loss_mse(optcode_batched, tensors::Tuple, batch_data, m::Int, n::Int, k::Int, inverse_code;
+function batched_loss_mse(optcode_batched, tensors, batch_data, m::Int, n::Int, k::Int, inverse_code;
                           batched_inverse_code=nothing)
+    ts = _ensure_tuple(tensors)
     stacked_batch = batch_data isa AbstractVector{<:AbstractMatrix} ? stack_image_batch(batch_data, m, n) : batch_data
     B = size(stacked_batch, ndims(stacked_batch))
     qubit_dims = fill(2, m + n)
 
     # Batched forward pass — single einsum call
-    fft_batched = batched_forward(optcode_batched, tensors, stacked_batch)
+    fft_batched = batched_forward(optcode_batched, ts, stacked_batch)
 
     # Per-image truncation (mask is content-dependent, cannot be batched)
     # Use map instead of mutation to keep Zygote happy
@@ -211,7 +215,7 @@ function batched_loss_mse(optcode_batched, tensors::Tuple, batch_data, m::Int, n
     end
 
     # Batched inverse pass
-    conj_tensors = conj.(tensors)
+    conj_tensors = conj.(ts)
     if batched_inverse_code !== nothing
         # Single einsum call for all B inverse transforms
         stacked_trunc = cat(truncated_slices...; dims=m + n + 1)
@@ -232,13 +236,6 @@ function batched_loss_mse(optcode_batched, tensors::Tuple, batch_data, m::Int, n
     return total_loss / B
 end
 
-# Vector→Tuple wrapper methods to avoid Zygote vector-vs-tuple tangent mismatch
-# when splatting. Same pattern as loss_function.
-batched_forward(oc, ts::AbstractVector, b::AbstractArray) = batched_forward(oc, Tuple(ts), b)
-batched_loss_l1(oc, ts::AbstractVector, b, m, n) = batched_loss_l1(oc, Tuple(ts), b, m, n)
-batched_loss_mse(oc, ts::AbstractVector, b, m, n, k, ic; kw...) = batched_loss_mse(oc, Tuple(ts), b, m, n, k, ic; kw...)
-batched_loss_l1(oc, ts::AbstractVector, b::AbstractArray) = batched_loss_l1(oc, Tuple(ts), b)
-
 # ============================================================================
 # Unified Batch Loss Interface
 # ============================================================================
@@ -248,52 +245,39 @@ batched_loss_l1(oc, ts::AbstractVector, b::AbstractArray) = batched_loss_l1(oc, 
 
 Average loss over a batch of images. Uses batched einsum if `batched_optcode` is provided.
 """
-function loss_function(tensors::AbstractVector, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
+function loss_function(tensors, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
                        pics::Vector{<:AbstractMatrix}, loss::AbstractLoss;
                        inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
-    return loss_function(Tuple(tensors), m, n, optcode, pics, loss;
-                         inverse_code=inverse_code, batched_optcode=batched_optcode,
-                         batched_inverse_code=batched_inverse_code)
-end
-
-function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
-                       pics::Vector{<:AbstractMatrix}, loss::AbstractLoss;
-                       inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
+    ts = _ensure_tuple(tensors)
     if batched_optcode !== nothing
-        return loss_function(tensors, m, n, optcode, stack_image_batch(pics, m, n), loss;
-                             inverse_code=inverse_code, batched_optcode=batched_optcode,
-                             batched_inverse_code=batched_inverse_code)
+        stacked = stack_image_batch(pics, m, n)
+        return _loss_function_batched(ts, m, n, stacked, loss, inverse_code, batched_optcode, batched_inverse_code)
     else
         n_imgs = length(pics)
-        total = zero(real(eltype(tensors[1])))
+        total = zero(real(eltype(ts[1])))
         for img in pics
-            total += loss_function(tensors, m, n, optcode, img, loss; inverse_code=inverse_code)
+            total += loss_function(ts, m, n, optcode, img, loss; inverse_code=inverse_code)
         end
         return total / n_imgs
     end
 end
 
-function loss_function(tensors::AbstractVector, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
+function loss_function(tensors, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
                        stacked_pics::AbstractArray, loss::AbstractLoss;
                        inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
-    return loss_function(Tuple(tensors), m, n, optcode, stacked_pics, loss;
-                         inverse_code=inverse_code, batched_optcode=batched_optcode,
-                         batched_inverse_code=batched_inverse_code)
+    ts = _ensure_tuple(tensors)
+    batched_optcode !== nothing || error("A pre-stacked batch requires batched_optcode")
+    return _loss_function_batched(ts, m, n, stacked_pics, loss, inverse_code, batched_optcode, batched_inverse_code)
 end
 
-function loss_function(tensors::Tuple, m::Int, n::Int, optcode::OMEinsum.AbstractEinsum,
-                       stacked_pics::AbstractArray, loss::AbstractLoss;
-                       inverse_code=nothing, batched_optcode=nothing, batched_inverse_code=nothing)
-    if batched_optcode !== nothing
-        if loss isa L1Norm
-            return batched_loss_l1(batched_optcode, tensors, stacked_pics)
-        elseif loss isa MSELoss
-            return batched_loss_mse(batched_optcode, tensors, stacked_pics, m, n, loss.k, inverse_code;
-                                    batched_inverse_code=batched_inverse_code)
-        else
-            error("unsupported loss type for batched dispatch: $(typeof(loss))")
-        end
+"""Dispatch batched loss computation to the appropriate loss-specific function."""
+function _loss_function_batched(tensors::Tuple, m, n, stacked_pics, loss, inverse_code, batched_optcode, batched_inverse_code)
+    if loss isa L1Norm
+        return batched_loss_l1(batched_optcode, tensors, stacked_pics)
+    elseif loss isa MSELoss
+        return batched_loss_mse(batched_optcode, tensors, stacked_pics, m, n, loss.k, inverse_code;
+                                batched_inverse_code=batched_inverse_code)
     else
-        error("A pre-stacked batch requires batched_optcode")
+        error("unsupported loss type for batched dispatch: $(typeof(loss))")
     end
 end

--- a/src/manifolds.jl
+++ b/src/manifolds.jl
@@ -154,32 +154,32 @@ function project(::UnitaryManifold, U::AbstractArray{T,3}, G::AbstractArray{T,3}
     return batched_matmul(U, S)
 end
 
-"""Batched Cayley retraction on U(n): `(I - α/2·W)⁻¹(I + α/2·W)·U` where `W = Ξ·U'`."""
-function retract(::UnitaryManifold, U::AbstractArray{T,3}, Xi::AbstractArray{T,3}, α) where T
+"""Batched Cayley retraction on U(n): `(I - α/2·W)⁻¹(I + α/2·W)·U` where `W = Ξ·U'`.
+Pass `I_batch` to reuse a pre-allocated identity tensor and avoid repeated allocations."""
+function retract(::UnitaryManifold, U::AbstractArray{T,3}, Xi::AbstractArray{T,3}, α; I_batch=nothing) where T
     RT = real(T)
     α_half = convert(RT, α) / 2
     d = size(U, 1)
     n = size(U, 3)
 
-    # W = Xi * U' projected to skew-Hermitian (Lie algebra).
-    # The projection ensures correctness even when Xi is not exactly tangent
-    # (e.g. Adam's element-wise scaled direction).
     W_raw = batched_matmul(Xi, batched_adjoint(U))
     W = (W_raw .- batched_adjoint(W_raw)) ./ 2
 
-    # Build batched identity
-    I_batch = zeros(T, d, d, n)
-    for k in 1:n
-        for i in 1:d
-            I_batch[i, i, k] = one(T)
+    if I_batch === nothing
+        I_b = zeros(T, d, d, n)
+        for k in 1:n
+            for i in 1:d
+                I_b[i, i, k] = one(T)
+            end
         end
+        I_b = convert(typeof(U), I_b)
+    else
+        I_b = I_batch
     end
-    I_batch = convert(typeof(U), I_batch)
 
-    lhs = I_batch .- α_half .* W   # I - α/2·W
-    rhs = I_batch .+ α_half .* W   # I + α/2·W
+    lhs = I_b .- α_half .* W
+    rhs = I_b .+ α_half .* W
 
-    # (I - α/2·W)⁻¹ (I + α/2·W) U
     return batched_matmul(batched_matmul(batched_inv(lhs), rhs), U)
 end
 
@@ -199,7 +199,7 @@ function project(::PhaseManifold, Z::AbstractArray{T,3}, G::AbstractArray{T,3}) 
 end
 
 """Batched U(1)^d retraction: normalize `z + alpha*xi`."""
-function retract(::PhaseManifold, Z::AbstractArray{T,3}, Xi::AbstractArray{T,3}, α) where T
+function retract(::PhaseManifold, Z::AbstractArray{T,3}, Xi::AbstractArray{T,3}, α; I_batch=nothing) where T
     RT = real(T)
     α_typed = convert(RT, α)
     y = Z .+ α_typed .* Xi

--- a/src/manifolds.jl
+++ b/src/manifolds.jl
@@ -162,9 +162,13 @@ function retract(::UnitaryManifold, U::AbstractArray{T,3}, Xi::AbstractArray{T,3
     d = size(U, 1)
     n = size(U, 3)
 
+    # W = Xi * U' projected to skew-Hermitian (Lie algebra).
+    # The projection ensures correctness even when Xi is not exactly tangent
+    # (e.g. Adam's element-wise scaled direction).
     W_raw = batched_matmul(Xi, batched_adjoint(U))
     W = (W_raw .- batched_adjoint(W_raw)) ./ 2
 
+    # Build or reuse batched identity
     if I_batch === nothing
         I_b = zeros(T, d, d, n)
         for k in 1:n
@@ -180,6 +184,7 @@ function retract(::UnitaryManifold, U::AbstractArray{T,3}, Xi::AbstractArray{T,3
     lhs = I_b .- α_half .* W
     rhs = I_b .+ α_half .* W
 
+    # (I - α/2·W)⁻¹ (I + α/2·W) U
     return batched_matmul(batched_matmul(batched_inv(lhs), rhs), U)
 end
 

--- a/src/manifolds.jl
+++ b/src/manifolds.jl
@@ -77,6 +77,20 @@ function batched_inv(A::AbstractArray{T,3}) where T
     return C
 end
 
+"""
+    _make_identity_batch(::Type{T}, d::Int, n::Int) -> Array{T,3}
+
+Create a `(d, d, n)` array of identity matrices. Used by optimizers for
+Cayley retraction pre-allocation and as fallback in `retract(::UnitaryManifold, ...)`.
+"""
+function _make_identity_batch(::Type{T}, d::Int, n::Int) where T
+    I_b = zeros(T, d, d, n)
+    for k in 1:n, i in 1:d
+        I_b[i, i, k] = one(T)
+    end
+    return I_b
+end
+
 # ============================================================================
 # Manifold Classification Utilities
 # ============================================================================
@@ -169,17 +183,7 @@ function retract(::UnitaryManifold, U::AbstractArray{T,3}, Xi::AbstractArray{T,3
     W = (W_raw .- batched_adjoint(W_raw)) ./ 2
 
     # Build or reuse batched identity
-    if I_batch === nothing
-        I_b = zeros(T, d, d, n)
-        for k in 1:n
-            for i in 1:d
-                I_b[i, i, k] = one(T)
-            end
-        end
-        I_b = convert(typeof(U), I_b)
-    else
-        I_b = I_batch
-    end
+    I_b = I_batch === nothing ? convert(typeof(U), _make_identity_batch(T, d, n)) : I_batch
 
     lhs = I_b .- α_half .* W
     rhs = I_b .+ α_half .* W

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -28,6 +28,9 @@ struct OptimizationState{ET, RT}
     current_tensors::Vector{<:AbstractMatrix}
 end
 
+_element_type(::OptimizationState{ET, RT}) where {ET, RT} = ET
+_real_type(::OptimizationState{ET, RT}) where {ET, RT} = RT
+
 """
     _common_setup(tensors)
 
@@ -186,10 +189,11 @@ end
 """
     _update_step!(opt, state, rg_batches, loss_fn, grad_norm_sq, opt_state, iter; cached_loss)
 
-Per-optimizer update dispatch. Returns `(accepted::Bool, cached_loss::RT)`.
+Per-optimizer update dispatch. Returns `cached_loss::RT` (NaN when not evaluated).
 
 - `RiemannianGD`: Armijo backtracking line search, evaluates loss multiple times.
-- `RiemannianAdam`: moment update + retract, does not evaluate loss.
+  Returns the accepted candidate loss, or `RT(NaN)` after exhausting line-search steps.
+- `RiemannianAdam`: moment update + retract, does not evaluate loss. Returns `RT(NaN)`.
 """
 function _update_step!(
     opt::RiemannianGD,
@@ -224,7 +228,7 @@ function _update_step!(
             for (manifold, _) in state.manifold_groups
                 state.point_batches[manifold] = last_cand_batches[manifold]
             end
-            return (true, candidate_loss)
+            return candidate_loss
         end
         alpha *= RT(opt.armijo_tau)
     end
@@ -233,7 +237,7 @@ function _update_step!(
     for (manifold, _) in state.manifold_groups
         state.point_batches[manifold] = last_cand_batches[manifold]
     end
-    return (false, RT(NaN))
+    return RT(NaN)
 end
 
 function _update_step!(
@@ -277,7 +281,7 @@ function _update_step!(
         state.point_batches[manifold] = new_batch
     end
 
-    return (true, RT(NaN))
+    return RT(NaN)
 end
 
 # ============================================================================
@@ -301,8 +305,8 @@ function _optimization_loop(
     loss_trace::Union{Nothing, Vector{Float64}} = nothing
 )
     state = _common_setup(tensors)
-    ET = typeof(state).parameters[1]
-    RT = typeof(state).parameters[2]
+    ET = _element_type(state)
+    RT = _real_type(state)
     opt_state = _init_optimizer_state(opt, state)
 
     cached_loss = RT(NaN)
@@ -330,7 +334,7 @@ function _optimization_loop(
         end
 
         # Per-optimizer update
-        accepted, cached_loss = _update_step!(
+        cached_loss = _update_step!(
             opt, state, rg_batches, loss_fn, grad_norm_sq, opt_state, iter;
             cached_loss=cached_loss
         )

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -15,6 +15,57 @@ abstract type AbstractRiemannianOptimizer end
 # ============================================================================
 
 """
+    OptimizationState{ET, RT}
+
+Bundles shared loop state built by `_common_setup`. Holds manifold groupings,
+batched point/gradient buffers, and the identity-batch cache for Cayley retraction.
+"""
+struct OptimizationState{ET, RT}
+    manifold_groups::Dict{AbstractRiemannianManifold, Vector{Int}}
+    point_batches::Dict{AbstractRiemannianManifold, AbstractArray}
+    grad_buf_batches::Dict{AbstractRiemannianManifold, AbstractArray}
+    ibatch_cache::Dict{AbstractRiemannianManifold, AbstractArray}
+    current_tensors::Vector{<:AbstractMatrix}
+end
+
+"""
+    _common_setup(tensors)
+
+Build an `OptimizationState` from the initial tensor list. Groups tensors by
+manifold, stacks into batched arrays, allocates gradient buffers, and creates
+identity-batch caches for `UnitaryManifold` groups via `_make_identity_batch`.
+"""
+function _common_setup(tensors::Vector{T}) where T <: AbstractMatrix
+    current_tensors = copy.(tensors)
+    ET = eltype(T)
+    RT = real(ET)
+
+    manifold_groups = group_by_manifold(tensors)
+
+    point_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+    grad_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+    ibatch_cache = Dict{AbstractRiemannianManifold, AbstractArray}()
+
+    for (manifold, indices) in manifold_groups
+        n_m = length(indices)
+        if n_m > 0
+            pb = stack_tensors(current_tensors, indices)
+            point_batches[manifold] = pb
+            grad_buf_batches[manifold] = similar(pb)
+            if manifold isa UnitaryManifold
+                d = size(pb, 1)
+                I_b = _make_identity_batch(ET, d, n_m)
+                ibatch_cache[manifold] = convert(typeof(pb), I_b)
+            end
+        end
+    end
+
+    return OptimizationState{ET, RT}(
+        manifold_groups, point_batches, grad_buf_batches, ibatch_cache, current_tensors
+    )
+end
+
+"""
     _compute_gradients(grad_fn, tensors)
 
 Compute Euclidean gradients via `grad_fn`. Returns `nothing` on NaN/Inf.
@@ -80,143 +131,6 @@ end
 RiemannianGD(; lr=0.01, armijo_c=1e-4, armijo_tau=0.5, max_ls_steps=10) =
     RiemannianGD(lr, armijo_c, armijo_tau, max_ls_steps)
 
-"""
-    optimize!(opt::RiemannianGD, tensors, loss_fn, grad_fn; max_iter=100, tol=1e-6, loss_trace=nothing)
-
-Run Riemannian gradient descent with Armijo line search. Returns optimized tensors.
-When `loss_trace::Vector{Float64}` is provided, per-iteration losses are appended to it.
-"""
-function optimize!(
-    opt::RiemannianGD,
-    tensors::Vector{T},
-    loss_fn,
-    grad_fn;
-    max_iter::Int = 100,
-    tol::Real = 1e-6,
-    loss_trace::Union{Nothing, Vector{Float64}} = nothing
-) where T <: AbstractMatrix
-
-    current_tensors = copy.(tensors)
-    ET = eltype(T)
-    RT = real(ET)
-
-    # Classify manifold types ONCE
-    manifold_groups = group_by_manifold(tensors)
-
-    # Pre-loop: build persistent batched state + pre-allocate reusable buffers
-    point_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-    grad_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-    ibatch_cache = Dict{AbstractRiemannianManifold, AbstractArray}()
-
-    for (manifold, indices) in manifold_groups
-        n_m = length(indices)
-        if n_m > 0
-            pb = stack_tensors(current_tensors, indices)
-            point_batches[manifold] = pb
-            grad_buf_batches[manifold] = similar(pb)
-            # Pre-allocate identity batch for UnitaryManifold Cayley retraction
-            if manifold isa UnitaryManifold
-                d = size(pb, 1)
-                I_b = zeros(ET, d, d, n_m)
-                for k in 1:n_m
-                    for i in 1:d
-                        I_b[i, i, k] = one(ET)
-                    end
-                end
-                ibatch_cache[manifold] = convert(typeof(pb), I_b)
-            end
-        end
-    end
-
-    # Cache loss across iterations to avoid redundant forward passes
-    cached_loss = RT(NaN)
-
-    for iter in 1:max_iter
-        # Unstack persistent batches for Zygote (which needs individual tensors)
-        for (manifold, indices) in manifold_groups
-            unstack_tensors!(current_tensors, point_batches[manifold], indices)
-        end
-
-        # Compute Euclidean gradients
-        euclidean_grads = _compute_gradients(grad_fn, current_tensors)
-        euclidean_grads === nothing && break
-
-        # Batched projection
-        rg_batches, grad_norm = _batched_project(
-            manifold_groups, point_batches, grad_buf_batches, euclidean_grads
-        )
-
-        grad_norm_sq = grad_norm^2
-
-        # Check convergence
-        if grad_norm < tol
-            break
-        end
-
-        # Armijo backtracking line search
-        current_loss = isnan(cached_loss) ? RT(loss_fn(current_tensors)) : cached_loss
-
-        alpha = RT(opt.lr)
-        accepted = false
-        last_cand_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-
-        for _ls in 1:opt.max_ls_steps
-            # Trial retraction at step size alpha
-            last_cand_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-            for (manifold, indices) in manifold_groups
-                pb = point_batches[manifold]
-                rg = rg_batches[manifold]
-                ib = get(ibatch_cache, manifold, nothing)
-                cand = retract(manifold, pb, .-rg, alpha; I_batch=ib)
-                last_cand_batches[manifold] = cand
-                unstack_tensors!(current_tensors, cand, indices)
-            end
-
-            candidate_loss = RT(loss_fn(current_tensors))
-
-            # Armijo sufficient decrease condition
-            if candidate_loss <= current_loss - RT(opt.armijo_c) * alpha * grad_norm_sq
-                # Accept: update persistent batches and cache the loss
-                for (manifold, _) in manifold_groups
-                    point_batches[manifold] = last_cand_batches[manifold]
-                end
-                cached_loss = candidate_loss
-                accepted = true
-                break
-            end
-            alpha *= RT(opt.armijo_tau)
-        end
-
-        if !accepted
-            # Fall back: use the last candidates (smallest step actually tried)
-            for (manifold, _) in manifold_groups
-                point_batches[manifold] = last_cand_batches[manifold]
-            end
-            cached_loss = RT(NaN)  # unknown after fallback
-        end
-
-        # Record per-iteration loss
-        if loss_trace !== nothing
-            if !isnan(cached_loss)
-                push!(loss_trace, Float64(cached_loss))
-            else
-                # Need to unstack for loss evaluation
-                for (manifold, indices) in manifold_groups
-                    unstack_tensors!(current_tensors, point_batches[manifold], indices)
-                end
-                push!(loss_trace, Float64(loss_fn(current_tensors)))
-            end
-        end
-    end
-
-    # Final unstack
-    for (manifold, indices) in manifold_groups
-        unstack_tensors!(current_tensors, point_batches[manifold], indices)
-    end
-
-    return current_tensors
-end
-
 # ============================================================================
 # RiemannianAdam -- Riemannian Adam Optimizer
 # ============================================================================
@@ -232,128 +146,240 @@ end
 RiemannianAdam(; lr=0.001, betas=(0.9, 0.999), eps=1e-8) =
     RiemannianAdam(lr, betas[1], betas[2], eps)
 
-"""
-    optimize!(opt::RiemannianAdam, tensors, loss_fn, grad_fn; max_iter=100, tol=1e-6, loss_trace=nothing)
+# ============================================================================
+# Per-Optimizer State Initialization
+# ============================================================================
 
-Run Riemannian Adam with momentum transport. Returns optimized tensors.
-When `loss_trace::Vector{Float64}` is provided, per-iteration losses are appended to it.
 """
-function optimize!(
+    _init_optimizer_state(opt::AbstractRiemannianOptimizer, state::OptimizationState)
+
+Initialize per-optimizer state. Returns `nothing` for GD, a NamedTuple of
+moment/direction buffers for Adam.
+"""
+_init_optimizer_state(::RiemannianGD, ::OptimizationState) = nothing
+
+function _init_optimizer_state(::RiemannianAdam, state::OptimizationState{ET, RT}) where {ET, RT}
+    m_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+    v_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+    dir_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+
+    for (manifold, indices) in state.manifold_groups
+        n_m = length(indices)
+        if n_m > 0
+            pb = state.point_batches[manifold]
+            dir_buf_batches[manifold] = similar(pb)
+
+            # Initialize moments: zeros on the same device as input
+            proto = state.current_tensors[indices[1]]
+            m_batches[manifold] = similar(proto, ET, size(pb)...) .* false
+            v_batches[manifold] = similar(proto, RT, size(pb)...) .* false
+        end
+    end
+
+    return (m_batches=m_batches, v_batches=v_batches, dir_buf_batches=dir_buf_batches)
+end
+
+# ============================================================================
+# Per-Optimizer Update Steps
+# ============================================================================
+
+"""
+    _update_step!(opt, state, rg_batches, loss_fn, grad_norm_sq, opt_state, iter; cached_loss)
+
+Per-optimizer update dispatch. Returns `(accepted::Bool, cached_loss::RT)`.
+
+- `RiemannianGD`: Armijo backtracking line search, evaluates loss multiple times.
+- `RiemannianAdam`: moment update + retract, does not evaluate loss.
+"""
+function _update_step!(
+    opt::RiemannianGD,
+    state::OptimizationState{ET, RT},
+    rg_batches,
+    loss_fn,
+    grad_norm_sq,
+    ::Nothing,  # GD has no opt_state
+    iter;
+    cached_loss::RT
+) where {ET, RT}
+    current_loss = isnan(cached_loss) ? RT(loss_fn(state.current_tensors)) : cached_loss
+
+    alpha = RT(opt.lr)
+    accepted = false
+    last_cand_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+
+    for _ls in 1:opt.max_ls_steps
+        last_cand_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+        for (manifold, indices) in state.manifold_groups
+            pb = state.point_batches[manifold]
+            rg = rg_batches[manifold]
+            ib = get(state.ibatch_cache, manifold, nothing)
+            cand = retract(manifold, pb, .-rg, alpha; I_batch=ib)
+            last_cand_batches[manifold] = cand
+            unstack_tensors!(state.current_tensors, cand, indices)
+        end
+
+        candidate_loss = RT(loss_fn(state.current_tensors))
+
+        if candidate_loss <= current_loss - RT(opt.armijo_c) * alpha * grad_norm_sq
+            for (manifold, _) in state.manifold_groups
+                state.point_batches[manifold] = last_cand_batches[manifold]
+            end
+            return (true, candidate_loss)
+        end
+        alpha *= RT(opt.armijo_tau)
+    end
+
+    # Fallback: use last candidates (smallest step tried)
+    for (manifold, _) in state.manifold_groups
+        state.point_batches[manifold] = last_cand_batches[manifold]
+    end
+    return (false, RT(NaN))
+end
+
+function _update_step!(
     opt::RiemannianAdam,
-    tensors::Vector{T},
+    state::OptimizationState{ET, RT},
+    rg_batches,
+    loss_fn,
+    grad_norm_sq,
+    opt_state,
+    iter;
+    cached_loss::RT
+) where {ET, RT}
+    beta1, beta2 = RT(opt.beta1), RT(opt.beta2)
+    bc1 = one(RT) - beta1^iter
+    bc2 = one(RT) - beta2^iter
+
+    m_batches = opt_state.m_batches
+    v_batches = opt_state.v_batches
+    dir_buf_batches = opt_state.dir_buf_batches
+
+    for (manifold, _indices) in state.manifold_groups
+        rg = rg_batches[manifold]
+        m_state = m_batches[manifold]
+        v_state = v_batches[manifold]
+        dir_buf = dir_buf_batches[manifold]
+
+        # In-place moment update (fused broadcasts)
+        @. m_state = beta1 * m_state + (one(RT) - beta1) * rg
+        @. v_state = beta2 * v_state + (one(RT) - beta2) * real(abs2(rg))
+
+        # Bias-corrected direction (in-place into dir_buf)
+        @. dir_buf = (m_state / bc1) / (sqrt(v_state / bc2) + RT(opt.eps))
+
+        # Retract
+        old_batch = state.point_batches[manifold]
+        ib = get(state.ibatch_cache, manifold, nothing)
+        new_batch = retract(manifold, old_batch, .-dir_buf, opt.lr; I_batch=ib)
+
+        # Transport momentum (re-project onto new tangent space)
+        m_batches[manifold] = transport(manifold, old_batch, new_batch, m_state)
+        state.point_batches[manifold] = new_batch
+    end
+
+    return (true, RT(NaN))
+end
+
+# ============================================================================
+# Shared Optimization Loop
+# ============================================================================
+
+"""
+    _optimization_loop(opt, tensors, loss_fn, grad_fn; max_iter, tol, loss_trace)
+
+Shared optimization loop. Delegates setup/gradient/convergence logic once,
+then calls `_update_step!` for per-optimizer behavior each iteration.
+Returns the optimized tensor vector.
+"""
+function _optimization_loop(
+    opt::AbstractRiemannianOptimizer,
+    tensors::Vector{<:AbstractMatrix},
     loss_fn,
     grad_fn;
     max_iter::Int = 100,
     tol::Real = 1e-6,
     loss_trace::Union{Nothing, Vector{Float64}} = nothing
-) where T <: AbstractMatrix
+)
+    state = _common_setup(tensors)
+    ET = typeof(state).parameters[1]
+    RT = typeof(state).parameters[2]
+    opt_state = _init_optimizer_state(opt, state)
 
-    current_tensors = copy.(tensors)
-    ET = eltype(T)
-    RT = real(ET)
-    beta1, beta2 = RT(opt.beta1), RT(opt.beta2)
-
-    # Classify manifold types ONCE
-    manifold_groups = group_by_manifold(tensors)
-
-    # Pre-loop: build persistent batched state + pre-allocate reusable buffers
-    point_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-    grad_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-    dir_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-    ibatch_cache = Dict{AbstractRiemannianManifold, AbstractArray}()
-
-    # Adam state: first moment (complex) and second moment (real) per manifold
-    m_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-    v_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
-
-    for (manifold, indices) in manifold_groups
-        n_m = length(indices)
-        if n_m > 0
-            pb = stack_tensors(current_tensors, indices)
-            point_batches[manifold] = pb
-            grad_buf_batches[manifold] = similar(pb)
-            dir_buf_batches[manifold] = similar(pb)
-
-            # Initialize moments: zeros on the same device as input
-            proto = tensors[indices[1]]
-            m_batches[manifold] = similar(proto, ET, size(pb)...) .* false  # zeros on same device
-            v_batches[manifold] = similar(proto, RT, size(pb)...) .* false
-
-            # Pre-allocate identity batch for UnitaryManifold Cayley retraction
-            if manifold isa UnitaryManifold
-                d = size(pb, 1)
-                I_b = zeros(ET, d, d, n_m)
-                for k in 1:n_m
-                    for i in 1:d
-                        I_b[i, i, k] = one(ET)
-                    end
-                end
-                ibatch_cache[manifold] = convert(typeof(pb), I_b)
-            end
-        end
-    end
+    cached_loss = RT(NaN)
 
     for iter in 1:max_iter
         # Unstack persistent batches for Zygote (which needs individual tensors)
-        for (manifold, indices) in manifold_groups
-            unstack_tensors!(current_tensors, point_batches[manifold], indices)
+        for (manifold, indices) in state.manifold_groups
+            unstack_tensors!(state.current_tensors, state.point_batches[manifold], indices)
         end
 
         # Compute Euclidean gradients
-        euclidean_grads = _compute_gradients(grad_fn, current_tensors)
+        euclidean_grads = _compute_gradients(grad_fn, state.current_tensors)
         euclidean_grads === nothing && break
 
         # Batched projection
         rg_batches, grad_norm = _batched_project(
-            manifold_groups, point_batches, grad_buf_batches, euclidean_grads
+            state.manifold_groups, state.point_batches, state.grad_buf_batches, euclidean_grads
         )
 
+        grad_norm_sq = grad_norm^2
+
+        # Check convergence
         if grad_norm < tol
             break
         end
 
-        # Bias correction factors
-        bc1 = one(RT) - beta1^iter
-        bc2 = one(RT) - beta2^iter
-
-        # Per-manifold Adam update
-        for (manifold, indices) in manifold_groups
-            rg = rg_batches[manifold]
-            m_state = m_batches[manifold]
-            v_state = v_batches[manifold]
-            dir_buf = dir_buf_batches[manifold]
-
-            # In-place moment update (fused broadcasts)
-            @. m_state = beta1 * m_state + (one(RT) - beta1) * rg
-            @. v_state = beta2 * v_state + (one(RT) - beta2) * real(abs2(rg))
-
-            # Bias-corrected direction (in-place into dir_buf)
-            @. dir_buf = (m_state / bc1) / (sqrt(v_state / bc2) + RT(opt.eps))
-
-            # Retract (use persistent point_batch directly)
-            old_batch = point_batches[manifold]
-            ib = get(ibatch_cache, manifold, nothing)
-            new_batch = retract(manifold, old_batch, .-dir_buf, opt.lr; I_batch=ib)
-
-            # Transport momentum (re-project onto new tangent space)
-            m_batches[manifold] = transport(manifold, old_batch, new_batch, m_state)
-            point_batches[manifold] = new_batch
-        end
+        # Per-optimizer update
+        accepted, cached_loss = _update_step!(
+            opt, state, rg_batches, loss_fn, grad_norm_sq, opt_state, iter;
+            cached_loss=cached_loss
+        )
 
         # Record per-iteration loss
         if loss_trace !== nothing
-            for (manifold, indices) in manifold_groups
-                unstack_tensors!(current_tensors, point_batches[manifold], indices)
+            if !isnan(cached_loss)
+                push!(loss_trace, Float64(cached_loss))
+            else
+                # Need to unstack for loss evaluation
+                for (manifold, indices) in state.manifold_groups
+                    unstack_tensors!(state.current_tensors, state.point_batches[manifold], indices)
+                end
+                push!(loss_trace, Float64(loss_fn(state.current_tensors)))
             end
-            push!(loss_trace, Float64(loss_fn(current_tensors)))
         end
     end
 
     # Final unstack
-    for (manifold, indices) in manifold_groups
-        unstack_tensors!(current_tensors, point_batches[manifold], indices)
+    for (manifold, indices) in state.manifold_groups
+        unstack_tensors!(state.current_tensors, state.point_batches[manifold], indices)
     end
 
-    return current_tensors
+    return state.current_tensors
+end
+
+# ============================================================================
+# Unified optimize! entry point
+# ============================================================================
+
+"""
+    optimize!(opt::AbstractRiemannianOptimizer, tensors, loss_fn, grad_fn; max_iter=100, tol=1e-6, loss_trace=nothing)
+
+Run Riemannian optimization on circuit `tensors`. Dispatches to `_optimization_loop`
+which uses per-optimizer hooks (`_init_optimizer_state`, `_update_step!`).
+Returns optimized tensors.
+
+When `loss_trace::Vector{Float64}` is provided, per-iteration losses are appended to it.
+"""
+function optimize!(
+    opt::AbstractRiemannianOptimizer,
+    tensors::Vector{<:AbstractMatrix},
+    loss_fn,
+    grad_fn;
+    max_iter::Int = 100,
+    tol::Real = 1e-6,
+    loss_trace::Union{Nothing, Vector{Float64}} = nothing
+)
+    return _optimization_loop(opt, tensors, loss_fn, grad_fn;
+                              max_iter=max_iter, tol=tol, loss_trace=loss_trace)
 end
 

--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -106,6 +106,7 @@ function optimize!(
     # Pre-loop: build persistent batched state + pre-allocate reusable buffers
     point_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
     grad_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+    ibatch_cache = Dict{AbstractRiemannianManifold, AbstractArray}()
 
     for (manifold, indices) in manifold_groups
         n_m = length(indices)
@@ -113,6 +114,17 @@ function optimize!(
             pb = stack_tensors(current_tensors, indices)
             point_batches[manifold] = pb
             grad_buf_batches[manifold] = similar(pb)
+            # Pre-allocate identity batch for UnitaryManifold Cayley retraction
+            if manifold isa UnitaryManifold
+                d = size(pb, 1)
+                I_b = zeros(ET, d, d, n_m)
+                for k in 1:n_m
+                    for i in 1:d
+                        I_b[i, i, k] = one(ET)
+                    end
+                end
+                ibatch_cache[manifold] = convert(typeof(pb), I_b)
+            end
         end
     end
 
@@ -154,7 +166,8 @@ function optimize!(
             for (manifold, indices) in manifold_groups
                 pb = point_batches[manifold]
                 rg = rg_batches[manifold]
-                cand = retract(manifold, pb, .-rg, alpha)
+                ib = get(ibatch_cache, manifold, nothing)
+                cand = retract(manifold, pb, .-rg, alpha; I_batch=ib)
                 last_cand_batches[manifold] = cand
                 unstack_tensors!(current_tensors, cand, indices)
             end
@@ -247,6 +260,7 @@ function optimize!(
     point_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
     grad_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
     dir_buf_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
+    ibatch_cache = Dict{AbstractRiemannianManifold, AbstractArray}()
 
     # Adam state: first moment (complex) and second moment (real) per manifold
     m_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
@@ -264,6 +278,18 @@ function optimize!(
             proto = tensors[indices[1]]
             m_batches[manifold] = similar(proto, ET, size(pb)...) .* false  # zeros on same device
             v_batches[manifold] = similar(proto, RT, size(pb)...) .* false
+
+            # Pre-allocate identity batch for UnitaryManifold Cayley retraction
+            if manifold isa UnitaryManifold
+                d = size(pb, 1)
+                I_b = zeros(ET, d, d, n_m)
+                for k in 1:n_m
+                    for i in 1:d
+                        I_b[i, i, k] = one(ET)
+                    end
+                end
+                ibatch_cache[manifold] = convert(typeof(pb), I_b)
+            end
         end
     end
 
@@ -306,7 +332,8 @@ function optimize!(
 
             # Retract (use persistent point_batch directly)
             old_batch = point_batches[manifold]
-            new_batch = retract(manifold, old_batch, .-dir_buf, opt.lr)
+            ib = get(ibatch_cache, manifold, nothing)
+            new_batch = retract(manifold, old_batch, .-dir_buf, opt.lr; I_batch=ib)
 
             # Transport momentum (re-project onto new tangent space)
             m_batches[manifold] = transport(manifold, old_batch, new_batch, m_state)

--- a/src/training.jl
+++ b/src/training.jl
@@ -182,7 +182,9 @@ function _train_basis_core(
         end
 
         # Compute validation loss
-        val_loss = _compute_validation_loss(validation_data, current_tensors, optcode, inverse_code, m, n, loss)
+        val_loss = _compute_validation_loss(validation_data, current_tensors, optcode, inverse_code, m, n, loss;
+                                             batched_optcode=batched_optcode,
+                                             batched_inverse_code=batched_inverse_code)
         avg_train_loss = isempty(epoch_losses) ? Inf : sum(epoch_losses) / length(epoch_losses)
 
         # Store losses for visualization
@@ -436,19 +438,27 @@ function load_loss_history(path::String)
     return TrainingHistory(train_losses, val_losses, step_train_losses, basis_name)
 end
 
-"""Compute average loss over validation set."""
+"""Compute average loss over validation set. Uses batched path when available."""
 function _compute_validation_loss(
     validation_data::Vector{<:AbstractMatrix},
     tensors::Vector,
     optcode::OMEinsum.AbstractEinsum,
     inverse_code::OMEinsum.AbstractEinsum,
     m::Int, n::Int,
-    loss::AbstractLoss
+    loss::AbstractLoss;
+    batched_optcode=nothing,
+    batched_inverse_code=nothing
 )
     isempty(validation_data) && return Inf
-    total = sum(loss_function(tensors, m, n, optcode, img, loss; inverse_code=inverse_code) 
-                for img in validation_data)
-    return total / length(validation_data)
+    if batched_optcode !== nothing
+        return loss_function(tensors, m, n, optcode, validation_data, loss;
+                             inverse_code=inverse_code, batched_optcode=batched_optcode,
+                             batched_inverse_code=batched_inverse_code)
+    else
+        total = sum(loss_function(tensors, m, n, optcode, img, loss; inverse_code=inverse_code)
+                    for img in validation_data)
+        return total / length(validation_data)
+    end
 end
 
 

--- a/src/training.jl
+++ b/src/training.jl
@@ -217,276 +217,140 @@ function _train_basis_core(
 end
 
 
-"""
-    train_basis(::Type{QFTBasis}, dataset; m, n, loss, epochs, steps_per_image,
-                optimizer, batch_size, device, ...)
+# ============================================================================
+# Per-Basis-Type Dispatch Interface
+# ============================================================================
 
-Train a QFTBasis on images. Returns `(basis, history)`.
-Key kwargs: `optimizer` (`RiemannianGD()`/`RiemannianAdam()`/`:gradient_descent`/`:adam`),
-`batch_size`, `device` (`:cpu`/`:gpu`).
-"""
-function train_basis(
-    ::Type{QFTBasis},
-    dataset::Vector{<:AbstractMatrix};
-    m::Int, n::Int,
-    loss::AbstractLoss = MSELoss(round(Int, 2^(m+n) * 0.1)),
-    epochs::Int = 3,
-    steps_per_image::Int = 200,
-    validation_split::Float64 = 0.2,
-    shuffle::Bool = true,
-    early_stopping_patience::Int = 2,
-    save_loss_path::Union{Nothing, String} = nothing,
-    optimizer::Union{Symbol, AbstractRiemannianOptimizer} = :gradient_descent,
-    batch_size::Int = 1,
-    device::Symbol = :cpu,
-    checkpoint_interval::Int = 0,
-    checkpoint_dir::Union{Nothing, String} = nothing
-)
-    @assert 0.0 <= validation_split < 1.0 "validation_split must be in [0, 1)"
-    @assert length(dataset) > 0 "Dataset must not be empty"
-    expected_size = (2^m, 2^n)
-    for (i, img) in enumerate(dataset)
-        @assert size(img) == expected_size "Image $i has size $(size(img)), expected $expected_size"
-    end
+_basis_name(::Type{QFTBasis}) = "QFT"
+_basis_name(::Type{EntangledQFTBasis}) = "Entangled QFT"
+_basis_name(::Type{TEBDBasis}) = "TEBD"
+_basis_name(::Type{MERABasis}) = "MERA"
 
-    # Initialize circuit
+function _init_circuit(::Type{QFTBasis}, m, n; kwargs...)
     optcode, initial_tensors = qft_code(m, n)
     inverse_code, _ = qft_code(m, n; inverse=true)
-
-    # Checkpoint callback: construct QFTBasis from tensors
-    build_fn = tensors -> QFTBasis(m, n, tensors, optcode, inverse_code)
-
-    final_tensors, _, train_losses, val_losses, step_train_losses = _train_basis_core(
-        dataset, optcode, inverse_code, initial_tensors, m, n, loss,
-        epochs, steps_per_image, validation_split, shuffle,
-        early_stopping_patience, "QFTBasis";
-        save_loss_path=save_loss_path, optimizer=optimizer,
-        batch_size=batch_size, device=device,
-        checkpoint_interval=checkpoint_interval, checkpoint_dir=checkpoint_dir,
-        build_basis_fn=build_fn
-    )
-
-    trained_basis = QFTBasis(m, n, final_tensors, optcode, inverse_code)
-    history = (train_losses=train_losses, val_losses=val_losses, step_train_losses=step_train_losses, basis_name="QFT")
-
-    return trained_basis, history
+    return optcode, inverse_code, initial_tensors
 end
 
-"""
-    train_basis(::Type{EntangledQFTBasis}, dataset; m, n, entangle_phases, ...)
-
-Train an EntangledQFTBasis on images. Same kwargs as QFTBasis plus `entangle_phases`.
-"""
-function train_basis(
-    ::Type{EntangledQFTBasis},
-    dataset::Vector{<:AbstractMatrix};
-    m::Int, n::Int,
-    entangle_phases::Union{Nothing, Vector{<:Real}} = nothing,
-    entangle_position::Symbol = :back,
-    loss::AbstractLoss = MSELoss(round(Int, 2^(m+n) * 0.1)),
-    epochs::Int = 3,
-    steps_per_image::Int = 200,
-    validation_split::Float64 = 0.2,
-    shuffle::Bool = true,
-    early_stopping_patience::Int = 2,
-    save_loss_path::Union{Nothing, String} = nothing,
-    optimizer::Union{Symbol, AbstractRiemannianOptimizer} = :gradient_descent,
-    batch_size::Int = 1,
-    device::Symbol = :cpu,
-    checkpoint_interval::Int = 0,
-    checkpoint_dir::Union{Nothing, String} = nothing
-)
-    @assert 0.0 <= validation_split < 1.0 "validation_split must be in [0, 1)"
-    @assert length(dataset) > 0 "Dataset must not be empty"
-    expected_size = (2^m, 2^n)
-    for (i, img) in enumerate(dataset)
-        @assert size(img) == expected_size "Image $i has size $(size(img)), expected $expected_size"
-    end
-
-    n_entangle = min(m, n)
-
-    # Initialize circuit
-    optcode, initial_tensors, _ = entangled_qft_code(m, n; entangle_phases=entangle_phases, entangle_position=entangle_position)
-    inverse_code, _, _ = entangled_qft_code(m, n; entangle_phases=entangle_phases, inverse=true, entangle_position=entangle_position)
-
-    # Checkpoint callback: construct EntangledQFTBasis from tensors
-    build_fn = tensors -> begin
-        eidx = get_entangle_tensor_indices(tensors, n_entangle)
-        phases = !isempty(eidx) ? extract_entangle_phases(tensors, eidx) :
-                 (entangle_phases === nothing ? zeros(n_entangle) : Float64.(entangle_phases))
-        EntangledQFTBasis(m, n, tensors, optcode, inverse_code, n_entangle, phases, entangle_position)
-    end
-
-    final_tensors, _, train_losses, val_losses, step_train_losses = _train_basis_core(
-        dataset, optcode, inverse_code, initial_tensors, m, n, loss,
-        epochs, steps_per_image, validation_split, shuffle,
-        early_stopping_patience, "EntangledQFTBasis";
-        save_loss_path=save_loss_path, optimizer=optimizer,
-        batch_size=batch_size, device=device,
-        checkpoint_interval=checkpoint_interval, checkpoint_dir=checkpoint_dir,
-        build_basis_fn=build_fn
-    )
-
-    # Extract trained phases
-    entangle_indices = get_entangle_tensor_indices(final_tensors, n_entangle)
-    trained_phases = if !isempty(entangle_indices)
-        extract_entangle_phases(final_tensors, entangle_indices)
-    else
-        entangle_phases === nothing ? zeros(n_entangle) : Float64.(entangle_phases)
-    end
-
-    trained_basis = EntangledQFTBasis(m, n, final_tensors, optcode, inverse_code, n_entangle, trained_phases, entangle_position)
-    history = (train_losses=train_losses, val_losses=val_losses, step_train_losses=step_train_losses, basis_name="Entangled QFT")
-
-    return trained_basis, history
+function _init_circuit(::Type{EntangledQFTBasis}, m, n;
+                       entangle_phases=nothing, entangle_position=:back, kwargs...)
+    optcode, initial_tensors, _ = entangled_qft_code(m, n; entangle_phases=entangle_phases,
+                                                      entangle_position=entangle_position)
+    inverse_code, _, _ = entangled_qft_code(m, n; entangle_phases=entangle_phases,
+                                             inverse=true, entangle_position=entangle_position)
+    return optcode, inverse_code, initial_tensors
 end
 
-"""
-    train_basis(::Type{TEBDBasis}, dataset; m, n, phases, ...)
-
-Train a TEBDBasis on images. Same kwargs as QFTBasis plus `phases` (initial TEBD gate phases).
-"""
-function train_basis(
-    ::Type{TEBDBasis},
-    dataset::Vector{<:AbstractMatrix};
-    m::Int, n::Int,
-    phases::Union{Nothing, Vector{<:Real}} = nothing,
-    loss::AbstractLoss = MSELoss(round(Int, 2^(m+n) * 0.1)),
-    epochs::Int = 3,
-    steps_per_image::Int = 200,
-    validation_split::Float64 = 0.2,
-    shuffle::Bool = true,
-    early_stopping_patience::Int = 2,
-    save_loss_path::Union{Nothing, String} = nothing,
-    optimizer::Union{Symbol, AbstractRiemannianOptimizer} = :gradient_descent,
-    batch_size::Int = 1,
-    device::Symbol = :cpu,
-    checkpoint_interval::Int = 0,
-    checkpoint_dir::Union{Nothing, String} = nothing
-)
-    @assert 0.0 <= validation_split < 1.0 "validation_split must be in [0, 1)"
-    @assert length(dataset) > 0 "Dataset must not be empty"
-    expected_size = (2^m, 2^n)
-    for (i, img) in enumerate(dataset)
-        @assert size(img) == expected_size "Image $i has size $(size(img)), expected $expected_size"
-    end
-
-    n_row_gates = m  # Row ring has m gates
-    n_col_gates = n  # Col ring has n gates
-    n_gates = n_row_gates + n_col_gates
-
-    # Initialize phases: use small random values if not provided
-    # Zero phases create a symmetric point where gradients are zero,
-    # preventing the optimizer from learning. Small random values break symmetry.
+function _init_circuit(::Type{TEBDBasis}, m, n; phases=nothing, kwargs...)
+    n_gates = m + n
     if phases === nothing
         phases = randn(n_gates) * 0.1
     end
-
-    # Initialize circuit
     optcode, initial_tensors, _, _ = tebd_code(m, n; phases=phases)
     inverse_code, _, _, _ = tebd_code(m, n; phases=phases, inverse=true)
-
-    # Checkpoint callback: construct TEBDBasis from tensors
-    build_fn = tensors -> begin
-        gidx = get_tebd_gate_indices(tensors, n_gates)
-        p = !isempty(gidx) ? extract_tebd_phases(tensors, gidx) :
-            (phases === nothing ? zeros(n_gates) : Float64.(phases))
-        TEBDBasis(m, n, tensors, optcode, inverse_code, n_row_gates, n_col_gates, p)
-    end
-
-    final_tensors, _, train_losses, val_losses, step_train_losses = _train_basis_core(
-        dataset, optcode, inverse_code, initial_tensors, m, n, loss,
-        epochs, steps_per_image, validation_split, shuffle,
-        early_stopping_patience, "TEBDBasis";
-        save_loss_path=save_loss_path, optimizer=optimizer,
-        batch_size=batch_size, device=device,
-        checkpoint_interval=checkpoint_interval, checkpoint_dir=checkpoint_dir,
-        build_basis_fn=build_fn
-    )
-
-    # Extract trained phases
-    gate_indices = get_tebd_gate_indices(final_tensors, n_gates)
-    trained_phases = if !isempty(gate_indices)
-        extract_tebd_phases(final_tensors, gate_indices)
-    else
-        phases === nothing ? zeros(n_gates) : Float64.(phases)
-    end
-
-    trained_basis = TEBDBasis(m, n, final_tensors, optcode, inverse_code, n_row_gates, n_col_gates, trained_phases)
-    history = (train_losses=train_losses, val_losses=val_losses, step_train_losses=step_train_losses, basis_name="TEBD")
-
-    return trained_basis, history
+    return optcode, inverse_code, initial_tensors
 end
 
-"""Train a MERABasis on images. Same kwargs as TEBDBasis."""
-function train_basis(
-    ::Type{MERABasis},
-    dataset::Vector{<:AbstractMatrix};
-    m::Int, n::Int,
-    phases::Union{Nothing, Vector{<:Real}} = nothing,
-    loss::AbstractLoss = MSELoss(round(Int, 2^(m+n) * 0.1)),
-    epochs::Int = 3,
-    steps_per_image::Int = 200,
-    validation_split::Float64 = 0.2,
-    shuffle::Bool = true,
-    early_stopping_patience::Int = 2,
-    save_loss_path::Union{Nothing, String} = nothing,
-    optimizer::Union{Symbol, AbstractRiemannianOptimizer} = :gradient_descent,
-    batch_size::Int = 1,
-    device::Symbol = :cpu,
-    checkpoint_interval::Int = 0,
-    checkpoint_dir::Union{Nothing, String} = nothing
-)
-    @assert 0.0 <= validation_split < 1.0 "validation_split must be in [0, 1)"
-    @assert length(dataset) > 0 "Dataset must not be empty"
-    expected_size = (2^m, 2^n)
-    for (i, img) in enumerate(dataset)
-        @assert size(img) == expected_size "Image $i has size $(size(img)), expected $expected_size"
-    end
-
+function _init_circuit(::Type{MERABasis}, m, n; phases=nothing, kwargs...)
     n_row_gates = m >= 2 ? 2 * (m - 1) : 0
     n_col_gates = n >= 2 ? 2 * (n - 1) : 0
     n_gates = n_row_gates + n_col_gates
-
-    # Initialize phases: use small random values if not provided
-    # Zero phases create a symmetric point where gradients are zero,
-    # preventing the optimizer from learning. Small random values break symmetry.
     if phases === nothing
         phases = randn(n_gates) * 0.1
     end
-
-    # Initialize circuit
     optcode, initial_tensors, _, _ = mera_code(m, n; phases=phases)
     inverse_code, _, _, _ = mera_code(m, n; phases=phases, inverse=true)
+    return optcode, inverse_code, initial_tensors
+end
 
-    # Checkpoint callback: construct MERABasis from tensors
-    build_fn = tensors -> begin
-        gidx = get_mera_gate_indices(tensors, n_gates)
-        p = !isempty(gidx) ? extract_mera_phases(tensors, gidx) :
-            (phases === nothing ? zeros(n_gates) : Float64.(phases))
-        MERABasis(m, n, tensors, optcode, inverse_code, n_row_gates, n_col_gates, p)
+function _build_basis(::Type{QFTBasis}, m, n, tensors, optcode, inverse_code; kwargs...)
+    return QFTBasis(m, n, tensors, optcode, inverse_code)
+end
+
+function _build_basis(::Type{EntangledQFTBasis}, m, n, tensors, optcode, inverse_code;
+                      entangle_phases=nothing, entangle_position=:back, kwargs...)
+    n_entangle = min(m, n)
+    eidx = get_entangle_tensor_indices(tensors, n_entangle)
+    phases = !isempty(eidx) ? extract_entangle_phases(tensors, eidx) :
+             (entangle_phases === nothing ? zeros(n_entangle) : Float64.(entangle_phases))
+    return EntangledQFTBasis(m, n, tensors, optcode, inverse_code, n_entangle, phases, entangle_position)
+end
+
+function _build_basis(::Type{TEBDBasis}, m, n, tensors, optcode, inverse_code;
+                      phases=nothing, kwargs...)
+    n_row_gates = m
+    n_col_gates = n
+    n_gates = n_row_gates + n_col_gates
+    gidx = get_tebd_gate_indices(tensors, n_gates)
+    trained_phases = !isempty(gidx) ? extract_tebd_phases(tensors, gidx) :
+                     (phases === nothing ? zeros(n_gates) : Float64.(phases))
+    return TEBDBasis(m, n, tensors, optcode, inverse_code, n_row_gates, n_col_gates, trained_phases)
+end
+
+function _build_basis(::Type{MERABasis}, m, n, tensors, optcode, inverse_code;
+                      phases=nothing, kwargs...)
+    n_row_gates = m >= 2 ? 2 * (m - 1) : 0
+    n_col_gates = n >= 2 ? 2 * (n - 1) : 0
+    n_gates = n_row_gates + n_col_gates
+    gidx = get_mera_gate_indices(tensors, n_gates)
+    trained_phases = !isempty(gidx) ? extract_mera_phases(tensors, gidx) :
+                     (phases === nothing ? zeros(n_gates) : Float64.(phases))
+    return MERABasis(m, n, tensors, optcode, inverse_code, n_row_gates, n_col_gates, trained_phases)
+end
+
+# ============================================================================
+# Generic train_basis
+# ============================================================================
+
+"""
+    train_basis(::Type{B}, dataset; m, n, loss, epochs, steps_per_image,
+                optimizer, batch_size, device, ...)
+
+Train any AbstractSparseBasis subtype on images. Returns `(basis, history)`.
+Basis-specific kwargs (e.g. `phases`, `entangle_phases`) are forwarded to
+`_init_circuit` and `_build_basis`.
+"""
+function train_basis(
+    ::Type{B},
+    dataset::Vector{<:AbstractMatrix};
+    m::Int, n::Int,
+    loss::AbstractLoss = MSELoss(round(Int, 2^(m+n) * 0.1)),
+    epochs::Int = 3,
+    steps_per_image::Int = 200,
+    validation_split::Float64 = 0.2,
+    shuffle::Bool = true,
+    early_stopping_patience::Int = 2,
+    save_loss_path::Union{Nothing, String} = nothing,
+    optimizer::Union{Symbol, AbstractRiemannianOptimizer} = :gradient_descent,
+    batch_size::Int = 1,
+    device::Symbol = :cpu,
+    checkpoint_interval::Int = 0,
+    checkpoint_dir::Union{Nothing, String} = nothing,
+    kwargs...
+) where B <: AbstractSparseBasis
+    @assert 0.0 <= validation_split < 1.0 "validation_split must be in [0, 1)"
+    @assert length(dataset) > 0 "Dataset must not be empty"
+    expected_size = (2^m, 2^n)
+    for (i, img) in enumerate(dataset)
+        @assert size(img) == expected_size "Image $i has size $(size(img)), expected $expected_size"
     end
+
+    optcode, inverse_code, initial_tensors = _init_circuit(B, m, n; kwargs...)
+    build_fn = tensors -> _build_basis(B, m, n, tensors, optcode, inverse_code; kwargs...)
 
     final_tensors, _, train_losses, val_losses, step_train_losses = _train_basis_core(
         dataset, optcode, inverse_code, initial_tensors, m, n, loss,
         epochs, steps_per_image, validation_split, shuffle,
-        early_stopping_patience, "MERABasis";
+        early_stopping_patience, _basis_name(B);
         save_loss_path=save_loss_path, optimizer=optimizer,
         batch_size=batch_size, device=device,
         checkpoint_interval=checkpoint_interval, checkpoint_dir=checkpoint_dir,
         build_basis_fn=build_fn
     )
 
-    # Extract trained phases
-    gate_indices = get_mera_gate_indices(final_tensors, n_gates)
-    trained_phases = if !isempty(gate_indices)
-        extract_mera_phases(final_tensors, gate_indices)
-    else
-        phases === nothing ? zeros(n_gates) : Float64.(phases)
-    end
-
-    trained_basis = MERABasis(m, n, final_tensors, optcode, inverse_code, n_row_gates, n_col_gates, trained_phases)
-    history = (train_losses=train_losses, val_losses=val_losses, step_train_losses=step_train_losses, basis_name="MERA")
+    trained_basis = build_fn(final_tensors)
+    history = (train_losses=train_losses, val_losses=val_losses,
+               step_train_losses=step_train_losses, basis_name=_basis_name(B))
 
     return trained_basis, history
 end

--- a/src/training.jl
+++ b/src/training.jl
@@ -123,10 +123,11 @@ function _train_basis_core(
             start_idx = (batch_idx - 1) * batch_size + 1
             end_idx = min(batch_idx * batch_size, length(training_data))
             batch = training_data[start_idx:end_idx]
+            stacked_batch = batched_optcode === nothing ? nothing : stack_image_batch(batch, m, n)
 
             # Construct loss function for this batch
             batch_loss_fn = if batched_optcode !== nothing
-                ts -> loss_function(ts, m, n, optcode, batch, loss;
+                ts -> loss_function(ts, m, n, optcode, stacked_batch, loss;
                                     inverse_code=inverse_code, batched_optcode=batched_optcode,
                                     batched_inverse_code=batched_inverse_code)
             else

--- a/test/loss_tests.jl
+++ b/test/loss_tests.jl
@@ -86,12 +86,6 @@ end
     @test l1_value isa Float64
     @test l1_value > 0.0
 
-    # Test L2Norm
-    loss_l2 = ParametricDFT.L2Norm()
-    l2_value = ParametricDFT.loss_function(tensors, m, n, optcode, pic, loss_l2)
-    @test l2_value isa Float64
-    @test l2_value > 0.0
-
     # Test MSELoss
     for k in [1, 5, 20, 2^(m+n)]
         loss_mse = ParametricDFT.MSELoss(k)
@@ -142,24 +136,6 @@ end
         @test isapprox(ParametricDFT.batched_loss_l1(batched_opt, tensors, stacked), per_image, rtol=1e-10)
     end
 
-    @testset "batched L2 loss matches per-image L2" begin
-        Random.seed!(42)
-        m, n = 2, 2
-        optcode, tensors_raw = ParametricDFT.qft_code(m, n)
-        tensors = [ComplexF64.(t) for t in tensors_raw]
-        n_gates = length(tensors)
-        B = 4
-        batch = [rand(ComplexF64, 2^m, 2^n) for _ in 1:B]
-
-        per_image = sum(ParametricDFT.loss_function(tensors, m, n, optcode, img, ParametricDFT.L2Norm()) for img in batch) / B
-        batched_flat, blabel = ParametricDFT.make_batched_code(optcode, n_gates)
-        batched_opt = ParametricDFT.optimize_batched_code(batched_flat, blabel, B)
-
-        @test isapprox(ParametricDFT.batched_loss_l2(batched_opt, tensors, batch, m, n), per_image, rtol=1e-10)
-        stacked = ParametricDFT.stack_image_batch(batch, m, n)
-        @test isapprox(ParametricDFT.batched_loss_l2(batched_opt, tensors, stacked), per_image, rtol=1e-10)
-    end
-
     @testset "batched MSE loss matches per-image MSE" begin
         Random.seed!(42)
         m, n = 2, 2
@@ -193,7 +169,6 @@ end
 
         for (loss_type, batched_fn) in [
             (ParametricDFT.L1Norm(), (opt, ts, b, m, n) -> ParametricDFT.batched_loss_l1(opt, ts, b, m, n)),
-            (ParametricDFT.L2Norm(), (opt, ts, b, m, n) -> ParametricDFT.batched_loss_l2(opt, ts, b, m, n)),
         ]
             batched_grad = Zygote.gradient(ts -> batched_fn(batched_opt, ts, batch, m, n), tensors)[1]
             per_image_grad = Zygote.gradient(tensors) do ts
@@ -238,8 +213,8 @@ end
         B = 3
         batch = [rand(ComplexF64, 2^m, 2^n) for _ in 1:B]
 
-        per_image = sum(ParametricDFT.loss_function(tensors, m, n, optcode, img, ParametricDFT.L2Norm()) for img in batch) / B
-        @test isapprox(ParametricDFT.batched_loss_l2(batched_opt, tensors, batch, m, n), per_image, rtol=1e-10)
+        per_image = sum(ParametricDFT.loss_function(tensors, m, n, optcode, img, ParametricDFT.L1Norm()) for img in batch) / B
+        @test isapprox(ParametricDFT.batched_loss_l1(batched_opt, tensors, batch, m, n), per_image, rtol=1e-10)
     end
 
     @testset "Zygote gradient through batched_loss_mse" begin

--- a/test/loss_tests.jl
+++ b/test/loss_tests.jl
@@ -138,6 +138,8 @@ end
         batched_opt = ParametricDFT.optimize_batched_code(batched_flat, blabel, B)
 
         @test isapprox(ParametricDFT.batched_loss_l1(batched_opt, tensors, batch, m, n), per_image, rtol=1e-10)
+        stacked = ParametricDFT.stack_image_batch(batch, m, n)
+        @test isapprox(ParametricDFT.batched_loss_l1(batched_opt, tensors, stacked), per_image, rtol=1e-10)
     end
 
     @testset "batched L2 loss matches per-image L2" begin
@@ -154,6 +156,8 @@ end
         batched_opt = ParametricDFT.optimize_batched_code(batched_flat, blabel, B)
 
         @test isapprox(ParametricDFT.batched_loss_l2(batched_opt, tensors, batch, m, n), per_image, rtol=1e-10)
+        stacked = ParametricDFT.stack_image_batch(batch, m, n)
+        @test isapprox(ParametricDFT.batched_loss_l2(batched_opt, tensors, stacked), per_image, rtol=1e-10)
     end
 
     @testset "batched MSE loss matches per-image MSE" begin
@@ -171,6 +175,8 @@ end
         batched_opt = ParametricDFT.optimize_batched_code(batched_flat, blabel, B)
 
         @test isapprox(ParametricDFT.batched_loss_mse(batched_opt, tensors, batch, m, n, k, optcode_inv), per_image, rtol=1e-10)
+        stacked = ParametricDFT.stack_image_batch(batch, m, n)
+        @test isapprox(ParametricDFT.batched_loss_mse(batched_opt, tensors, stacked, m, n, k, optcode_inv), per_image, rtol=1e-10)
     end
 
     @testset "Zygote gradients through batched losses" begin

--- a/test/loss_tests.jl
+++ b/test/loss_tests.jl
@@ -167,17 +167,16 @@ end
         batched_flat, blabel = ParametricDFT.make_batched_code(optcode, n_gates)
         batched_opt = ParametricDFT.optimize_batched_code(batched_flat, blabel, B)
 
-        for (loss_type, batched_fn) in [
-            (ParametricDFT.L1Norm(), (opt, ts, b, m, n) -> ParametricDFT.batched_loss_l1(opt, ts, b, m, n)),
-        ]
-            batched_grad = Zygote.gradient(ts -> batched_fn(batched_opt, ts, batch, m, n), tensors)[1]
-            per_image_grad = Zygote.gradient(tensors) do ts
-                sum(ParametricDFT.loss_function(ts, m, n, optcode, img, loss_type) for img in batch) / B
-            end[1]
+        loss_type = ParametricDFT.L1Norm()
+        batched_fn = (opt, ts, b, m, n) -> ParametricDFT.batched_loss_l1(opt, ts, b, m, n)
 
-            for i in 1:n_gates
-                @test isapprox(batched_grad[i], per_image_grad[i], rtol=1e-6)
-            end
+        batched_grad = Zygote.gradient(ts -> batched_fn(batched_opt, ts, batch, m, n), tensors)[1]
+        per_image_grad = Zygote.gradient(tensors) do ts
+            sum(ParametricDFT.loss_function(ts, m, n, optcode, img, loss_type) for img in batch) / B
+        end[1]
+
+        for i in 1:n_gates
+            @test isapprox(batched_grad[i], per_image_grad[i], rtol=1e-6)
         end
     end
 

--- a/test/manifold_tests.jl
+++ b/test/manifold_tests.jl
@@ -274,6 +274,18 @@
         @test all_indices == collect(1:length(tensors))
     end
 
+    @testset "_make_identity_batch" begin
+        I_b = ParametricDFT._make_identity_batch(ComplexF64, 3, 4)
+        @test size(I_b) == (3, 3, 4)
+        for k in 1:4
+            @test I_b[:, :, k] ≈ Matrix{ComplexF64}(I, 3, 3)
+        end
+        # Real type
+        I_r = ParametricDFT._make_identity_batch(Float64, 2, 5)
+        @test eltype(I_r) == Float64
+        @test size(I_r) == (2, 2, 5)
+    end
+
     @testset "stack/unstack round-trip generalized" begin
         Random.seed!(52)
         for d in [2, 3, 4]

--- a/test/manifold_tests.jl
+++ b/test/manifold_tests.jl
@@ -167,6 +167,32 @@
         end
     end
 
+    @testset "UnitaryManifold retract with pre-allocated I_batch" begin
+        Random.seed!(61)
+        um = ParametricDFT.UnitaryManifold()
+        d, n = 4, 5
+        U = Array{ComplexF64}(undef, d, d, n)
+        for k in 1:n
+            Q, _ = qr(randn(ComplexF64, d, d))
+            U[:, :, k] = Matrix{ComplexF64}(Q)
+        end
+        G = randn(ComplexF64, d, d, n)
+        Xi = ParametricDFT.project(um, U, G)
+
+        I_b = zeros(ComplexF64, d, d, n)
+        for k in 1:n, i in 1:d
+            I_b[i, i, k] = one(ComplexF64)
+        end
+
+        result_with    = ParametricDFT.retract(um, U, Xi, 0.1; I_batch=I_b)
+        result_without = ParametricDFT.retract(um, U, Xi, 0.1)
+
+        @test result_with ≈ result_without atol=1e-14
+        for k in 1:n
+            @test result_with[:, :, k]' * result_with[:, :, k] ≈ Matrix{ComplexF64}(I, d, d) atol=1e-10
+        end
+    end
+
     @testset "PhaseManifold project" begin
         Random.seed!(48)
         pm = ParametricDFT.PhaseManifold()

--- a/test/optimizer_tests.jl
+++ b/test/optimizer_tests.jl
@@ -125,6 +125,39 @@ using RecursiveArrayTools
         end
     end
 
+    @testset "_common_setup builds OptimizationState" begin
+        Random.seed!(42)
+        m, n = 2, 2
+        _, tensors_raw = ParametricDFT.qft_code(m, n)
+        tensors = [Matrix{ComplexF64}(t) for t in tensors_raw]
+
+        state = ParametricDFT._common_setup(tensors)
+        @test state isa ParametricDFT.OptimizationState
+        @test !isempty(state.manifold_groups)
+        all_indices = vcat(values(state.manifold_groups)...)
+        @test sort(all_indices) == 1:length(tensors)
+        total_slices = sum(size(pb, 3) for pb in values(state.point_batches))
+        @test total_slices == length(tensors)
+    end
+
+    @testset "_init_optimizer_state dispatches correctly" begin
+        Random.seed!(42)
+        m, n = 2, 2
+        _, tensors_raw = ParametricDFT.qft_code(m, n)
+        tensors = [Matrix{ComplexF64}(t) for t in tensors_raw]
+
+        state = ParametricDFT._common_setup(tensors)
+
+        gd_state = ParametricDFT._init_optimizer_state(RiemannianGD(), state)
+        @test gd_state === nothing
+
+        adam_state = ParametricDFT._init_optimizer_state(RiemannianAdam(), state)
+        @test adam_state !== nothing
+        @test adam_state isa NamedTuple
+        @test haskey(adam_state, :m_batches)
+        @test haskey(adam_state, :v_batches)
+    end
+
     @testset "loss_trace records per-iteration losses" begin
         tensors, loss_fn, grad_fn = make_test_problem(seed=42)
 

--- a/test/training_tests.jl
+++ b/test/training_tests.jl
@@ -89,26 +89,6 @@ end
         @test basis.n == n
     end
 
-    @testset "training with L2Norm" begin
-        Random.seed!(42)
-
-        m, n = 3, 3
-        dataset = [rand(Float64, 8, 8) for _ in 1:4]
-
-        basis, _ = train_basis(
-            QFTBasis, dataset;
-            m=m, n=n,
-            loss=ParametricDFT.L2Norm(),
-            epochs=1,
-            steps_per_image=3,
-            validation_split=0.25,
-        )
-
-        @test basis isa QFTBasis
-        @test basis.m == m
-        @test basis.n == n
-    end
-
     @testset "training without shuffle" begin
         Random.seed!(42)
 
@@ -319,7 +299,7 @@ end
         @test final_loss < initial_loss
     end
 
-    @testset "gradient_descent with batch_size > 1 and L2Norm" begin
+    @testset "gradient_descent with batch_size > 1" begin
         Random.seed!(42)
         m, n = 2, 2
         dataset = [rand(Float64, 4, 4) for _ in 1:6]
@@ -327,7 +307,7 @@ end
         basis, history = train_basis(
             QFTBasis, dataset;
             m=m, n=n,
-            loss=ParametricDFT.L2Norm(),
+            loss=ParametricDFT.L1Norm(),
             epochs=3,
             steps_per_image=5,
             batch_size=3,

--- a/test/training_tests.jl
+++ b/test/training_tests.jl
@@ -3,6 +3,33 @@
 # ============================================================================
 
 # ============================================================================
+# Dispatch interface: _init_circuit, _build_basis, _basis_name
+# ============================================================================
+
+@testset "_init_circuit and _build_basis dispatch" begin
+    for (BasisType, m, n, kwargs) in [
+        (QFTBasis, 3, 3, NamedTuple()),
+        (EntangledQFTBasis, 3, 3, NamedTuple()),
+        (TEBDBasis, 2, 2, (phases=randn(4) * 0.1,)),
+        (MERABasis, 2, 2, (phases=randn(4) * 0.1,)),
+    ]
+        @testset "$BasisType" begin
+            optcode, inverse_code, tensors = ParametricDFT._init_circuit(BasisType, m, n; kwargs...)
+            @test optcode isa OMEinsum.AbstractEinsum
+            @test inverse_code isa OMEinsum.AbstractEinsum
+            @test !isempty(tensors)
+
+            basis = ParametricDFT._build_basis(BasisType, m, n, tensors, optcode, inverse_code; kwargs...)
+            @test basis isa BasisType
+            @test basis.m == m
+            @test basis.n == n
+
+            @test ParametricDFT._basis_name(BasisType) isa String
+        end
+    end
+end
+
+# ============================================================================
 # Common training: basic smoke test for all basis types
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- pre-stack image batches before optimizer iterations so batched GPU losses do not rebuild identical batch tensors on each AD/loss evaluation
- add pre-stacked batch loss APIs and tests for L1/L2/MSE
- update `examples/optimizer_benchmark.jl` to use QuickDraw and compare customized Riemannian GD with Manopt.jl Riemannian gradient descent using equal full-batch step counts
- set the benchmark GPU selection to device 1
- update the benchmark submodule pointer to include the GPU profiling tool from zazabap/ParametricDFT-Benchmarks.jl#2

## Testing
- `julia --project=. -e 'using ParametricDFT, Test, Random, OMEinsum, Zygote; include("test/loss_tests.jl")'`\n- `julia --project=. -e 'using ParametricDFT, Test, Random, LinearAlgebra; include("test/training_tests.jl")'`\n- `julia --project=. -e 'Meta.parseall(read("examples/optimizer_benchmark.jl", String)); Meta.parseall(read("examples/benchmark/profile_gpu_training.jl", String)); println("parse ok")'`\n\n## Notes\n- GPU 1 exists on this machine (`nvidia-smi -L` shows two RTX 3090s), but CUDA returned `ERROR_NOT_PERMITTED` when selecting device 1, and `CUDA_VISIBLE_DEVICES=1` reported no CUDA device. I could not complete the live GPU smoke run here.\n- `docs/drafts/` was left untracked.\n