### PR TITLE
Reuse Armijo Dict + per-tensor NaN/Inf diagnostic

### DIFF
--- a/src/optimizers.jl
+++ b/src/optimizers.jl
@@ -71,7 +71,9 @@ end
 """
     _compute_gradients(grad_fn, tensors)
 
-Compute Euclidean gradients via `grad_fn`. Returns `nothing` on NaN/Inf.
+Compute Euclidean gradients via `grad_fn`. Returns `nothing` on NaN/Inf,
+after logging which tensor index carried the non-finite value (and the
+count of each kind) to aid debugging of divergent runs.
 """
 function _compute_gradients(grad_fn, tensors)
     euclidean_grads_raw = grad_fn(tensors)
@@ -84,9 +86,15 @@ function _compute_gradients(grad_fn, tensors)
         for i in eachindex(raw)
     ]
 
-    # Check for NaN/Inf in gradients
-    if any(g -> !all(isfinite, g), euclidean_grads)
-        return nothing
+    # Per-tensor NaN/Inf diagnostic. Walk once; on the first non-finite tensor,
+    # report which index and the NaN/Inf counts, then stop.
+    for (i, g) in enumerate(euclidean_grads)
+        if !all(isfinite, g)
+            n_nan = count(isnan, g)
+            n_inf = count(isinf, g)
+            @warn "Non-finite gradient — optimizer will stop" tensor_index=i n_nan=n_nan n_inf=n_inf
+            return nothing
+        end
     end
 
     return euclidean_grads
@@ -209,10 +217,11 @@ function _update_step!(
 
     alpha = RT(opt.lr)
     accepted = false
+    # Reused across every line-search trial: keys are manifold types (stable
+    # across trials), so overwriting entries is equivalent to fresh allocation.
     last_cand_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
 
     for _ls in 1:opt.max_ls_steps
-        last_cand_batches = Dict{AbstractRiemannianManifold, AbstractArray}()
         for (manifold, indices) in state.manifold_groups
             pb = state.point_batches[manifold]
             rg = rg_batches[manifold]


### PR DESCRIPTION
Two small, independent changes from the speedup/DX checklist in #70. Both are CPU-testable; no GPU required to verify.

## Changes

### 1. Reuse `last_cand_batches` across Armijo trials (perf)

`_update_step!(::RiemannianGD, ...)` was allocating a fresh `Dict{AbstractRiemannianManifold, AbstractArray}()` on every line-search trial. The keys are the manifold types in `state.manifold_groups`, which are stable across trials, so overwriting entries is equivalent to allocating a fresh Dict.

Moving the allocation out of the `for _ls in 1:opt.max_ls_steps` loop saves up to `max_ls_steps - 1` Dict allocations per iteration (9 at default settings). The outer declaration was already present; it is now actually used.

Tiny per-iteration GC relief. No behavioural change.

### 2. Per-tensor NaN/Inf diagnostic in `_compute_gradients` (DX)

Previously any non-finite gradient caused a silent return of `nothing`, leaving the user to guess which tensor diverged and how. The new version walks the gradient list once; on the first non-finite tensor, emits

```
┌ Warning: Non-finite gradient — optimizer will stop
│   tensor_index = 3
│   n_nan = 4
│   n_inf = 0
```

and then returns `nothing` as before. No behavioural change on the happy path.

## Verification

- `Pkg.test()` passes (exit 0).
- Unitarity spot-check with both `RiemannianGD` and `RiemannianAdam` for 20 iterations on an L1 loss: `max|UU† − I|` stays at ~1e-15 throughout (machine epsilon), confirming the Riemannian update is untouched.

## Why this scope

These are the two smallest items on the #70 checklist that don't require GPU for verification. Larger items there (batched `topk_truncate`, Float32 path, fused Cayley kernel, parallel Armijo, removing the Zygote pack/unpack cycle) need either GPU benchmarks or a more substantial refactor; doing them as a separate series lets reviewers see each in isolation.

Refs: #70, #24.